### PR TITLE
typo fix: remove unwanted tilde

### DIFF
--- a/hyperswitch-open-source/local-setup/run-web-client.md
+++ b/hyperswitch-open-source/local-setup/run-web-client.md
@@ -5,7 +5,7 @@ description: Run the checkout page locally
 # 💻 Run web client
 
 {% hint style="info" %}
-\`\`\`In this section, you will run the Hyperswitch web client SDK on your machine
+In this section, you will run the Hyperswitch web client SDK on your machine
 {% endhint %}
 
 Accept payments from around the globe with a secure, Unified Checkout that gives your customers the best in class payment experience


### PR DESCRIPTION
![image](https://github.com/juspay/hyperswitch-docs/assets/25717858/c290a423-6252-4517-9134-4265fffc707c)

I guess the above tilde is unwanted - hence removing.