### PR TITLE
refactor(apple-pay): Add a note in apple pay web flow as the feature needs to be enabled for some connectors

### DIFF
--- a/hyperswitch-cloud/payment-methods-setup/wallets/apple-pay/web-domain.md
+++ b/hyperswitch-cloud/payment-methods-setup/wallets/apple-pay/web-domain.md
@@ -6,10 +6,10 @@ description: Enable Apple pay on your web domains
 
 ## **Steps to configure Apple Pay on Hyperswitch**
 
-* Login to [Hyperswitch control center](https://app.hyperswitch.io/)
-* In the Processor tab, select desired connector
-* While selecting Payment Methods, click on Apple Pay in the Wallet section
-* Select the Web Domain option
+- Login to [Hyperswitch control center](https://app.hyperswitch.io/)
+- In the Processor tab, select desired connector
+- While selecting Payment Methods, click on Apple Pay in the Wallet section
+- Select the Web Domain option
 
 <div data-full-width="false">
 
@@ -17,8 +17,27 @@ description: Enable Apple pay on your web domains
 
 </div>
 
-* Download the domain verification file using the button available
-* Host this file on your server at _`merchant_domain`_`/.well-known/apple-developer-merchantid-domain-association`
-* Enter the domain name where you have hosted the domain verification file
-* Click on verify and enable to complete your setup
+- Download the domain verification file using the button available
+- Host this file on your server at _`merchant_domain`_`/.well-known/apple-developer-merchantid-domain-association`
+- Enter the domain name where you have hosted the domain verification file
+- Click on verify and enable to complete your setup
 
+{% hint style="warning" %}
+Please note since the Apple Pay Web Domain flow involves decryption at Hyperswitch, you would need to write to your payment processor to get this feature enabled for your account. Stripe is one among them.
+{% endhint %}
+
+<details>
+
+<summary>You can use the following text in the email</summary>
+
+* Attach our PCI DSS AoC certificate and copy our Support team (biz@hyperswitch.io).
+
+* Stripe Account id: <`Enter your account id:` you can find it [here](https://dashboard.stripe.com/settings/user)>
+
+* A detailed business description:
+<`One sentence about your business`>. The business operates across `xx` countries and has customers across the world.
+
+* Feature Request:
+We are using Hyperswitch, a Level 1 PCI DSS 3.2.1 compliant Payments Orchestrator, to manage payments on our website. In addition to Stripe, since we are using other processors as well to process payments across multiple geographies, we wanted to use Hyperswitch’s Payment Processing certificate to decrypt Apple pay tokens and send the decrypted Apple pay tokens to Stripe. So, please enable processing decrypted Apple pay token feature on our Stripe account. We’ve attached Hyperswitch’s PCI DSS AoC for reference.
+
+</details>


### PR DESCRIPTION
Apple Pay Web Domain flow involves decryption at Hyperswitch, merchants would need to write to there payment processor to get this feature enabled. Hence having a note in the docs.