### PR TITLE
fix(docs): repair broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ cover: .gitbook/assets/Hero visual V6 (2).png
 coverY: 0
 metaLinks:
   alternates:
-    - /broken/pages/XoPzGnl6gFOvbu2eVGxQ
+    - ./
 ---
 
 # Exploration Guide
@@ -31,7 +31,7 @@ Spin up a working integration with minimal effort. Choose the path that fits you
 
 <summary><strong>Cloud Sandbox (Hyperswitch Hosted Test Environment)</strong></summary>
 
-[Try Hyperswitch →](/broken/pages/7ZGzFcNnCa2qvaHaWZF2)\
+[Try Hyperswitch →](https://app.hyperswitch.io)\
 Launch a ready-to-use Control Center test environment. No setup required, just log in and run your first transaction.
 
 </details>
@@ -40,7 +40,7 @@ Launch a ready-to-use Control Center test environment. No setup required, just l
 
 <summary><strong>Local Deployment (Docker)</strong></summary>
 
-[Set up Docker Locally →](/broken/pages/jgjmuwMSXAegPUshFW5j)\
+[Set up Docker Locally →](./setup-hyperswitch-locally/run-hyperswitch.md)\
 Perfect for developers who want local control and flexibility. You'll launch a ready-to-use Control Center environment.
 
 </details>
@@ -49,8 +49,8 @@ Perfect for developers who want local control and flexibility. You'll launch a r
 
 <summary><strong>API-first Integration</strong></summary>
 
-[API Reference →](/broken/pages/LKuAfum9EKsnM93AWZOE)\
-[Use Postman Collection →](/broken/pages/6oAUAUulNGlVVKqcr0If)\
+[API Reference →](https://api-reference.hyperswitch.io/)\
+[Use Postman Collection →](./learn-more/test-payments-through-newman-wrapped-in-rust.md)\
 Build a custom backend integration from scratch.
 
 > ⚠️ To authenticate API requests, you’ll need a username and password from either:\
@@ -63,7 +63,7 @@ Build a custom backend integration from scratch.
 
 <summary><strong>Launch a Scalable Hyperswitch Instance on AWS</strong></summary>
 
-[AWS Deployment →](/broken/pages/GYO8EiqQEVLNkJmilwfM)
+[AWS Deployment →](./deploy-hyperswitch-on-aws/deploy-hyperswitch/README.md)
 
 Launch Hyperswitch on your own AWS infrastructure with our step-by-step deployment guide. Ideal for teams looking for flexibility, control, and production-ready scalability.
 
@@ -73,7 +73,7 @@ Launch Hyperswitch on your own AWS infrastructure with our step-by-step deployme
 
 <summary><strong>Scalable, Self-Hosted Deployment | Helm Charts for GCP &#x26; Azure</strong></summary>
 
-[Deploy on GCP or Azure →](/broken/pages/eazTcZAFUC7fKMUoqC76)
+[Deploy on GCP or Azure →](./self-hosting-space/hyperswitch-open-source/)
 
 Install Hyperswitch on your cloud infrastructure using Helm charts for Kubernetes. This method gives you full control over your environment and is ideal for teams deploying on GCP, Azure, or any Kubernetes-compatible platform.
 
@@ -87,11 +87,11 @@ See Hyperswitch in action by sending your first test transaction via the cloud s
 
 <summary><strong>Test a payment | Your First Hello World with Hyperswitch</strong></summary>
 
-[Control Center](/broken/pages/l28HCGRBvHUVXZcSIrCF) | Accessible through cloud sandbox or Docker
+[Control Center](./self-hosting-space/hyperswitch-open-source/account-setup/using-hyperswitch-control-center.md) | Accessible through cloud sandbox or Docker
 
-[API ](/broken/pages/6oAUAUulNGlVVKqcr0If)| Accessible through the Postman Collection
+[API ](./learn-more/test-payments-through-newman-wrapped-in-rust.md)| Accessible through the Postman Collection
 
-[Learn how the SDK, control center and backend work together](/broken/pages/yxQ8DSoPoTLZSxyImSgc)
+[Learn how the SDK, control center and backend work together](./about-hyperswitch/sdk-payment-flows.md)
 
 </details>
 


### PR DESCRIPTION
## Summary
Fixed 10 broken GitBook links (`/broken/pages/*`) in the README.md file by replacing them with correct internal paths and external URLs.

## Changes Made
- Meta alternates → `./`
- Cloud Sandbox link → `https://app.hyperswitch.io`
- Docker Local Setup → `./setup-hyperswitch-locally/run-hyperswitch.md`
- API Reference → `https://api-reference.hyperswitch.io/`
- Postman Collection → `./learn-more/test-payments-through-newman-wrapped-in-rust.md`
- AWS Deployment → `./deploy-hyperswitch-on-aws/deploy-hyperswitch/README.md`
- GCP/Azure Deployment → `./self-hosting-space/hyperswitch-open-source/`
- Control Center → `./self-hosting-space/hyperswitch-open-source/account-setup/using-hyperswitch-control-center.md`
- API (testing) → `./learn-more/test-payments-through-newman-wrapped-in-rust.md`
- SDK/Backend workflow → `./about-hyperswitch/sdk-payment-flows.md`

All links have been verified to exist in the repository or confirmed as valid external URLs.
