### PR TITLE
docs(braintree): refresh capabilities and webhook details

### DIFF
--- a/integration-space/connectors-integrations/available-connectors/braintree.md
+++ b/integration-space/connectors-integrations/available-connectors/braintree.md
@@ -1,7 +1,7 @@
 ---
 description: >-
-  Accept payments through Braintree via Hyperswitch — covers prerequisites, API
-  credentials, and webhook configuration.
+  Connect Braintree to Hyperswitch and review the capabilities declared by the
+  connector implementation.
 metaLinks:
   alternates:
     - braintree.md
@@ -9,55 +9,53 @@ metaLinks:
 
 # Braintree
 
-Braintree connects to Hyperswitch as a `PaymentGateway` connector using `SignatureKey` authentication — three credentials (Merchant ID, Public Key, Private Key) are required. Unlike most connectors that use a Bearer token, Braintree authenticates requests using HTTP Basic auth where the Public Key is the username and the Private Key is the password, Base64-encoded as `Authorization: Basic base64(public_key:private_key)`. All payment operations use Braintree's GraphQL API (not REST), which Hyperswitch handles transparently via its connector implementation.
+Braintree is a payment gateway integration in Hyperswitch.
 
-### Connector-Specific Notes
+## Status and capabilities
 
-- **Authentication model:** Three-credential `SignatureKey` — Merchant ID (key1), Public Key (api_key), and Private Key (api_secret). The Public Key and Private Key together form HTTP Basic auth credentials (`Authorization: Basic base64(public_key:private_key)`). The Merchant ID is used to scope all requests to your Braintree merchant account.
-- **GraphQL-based API:** Braintree uses GraphQL mutations for payment operations, not REST endpoints. Hyperswitch constructs the appropriate GraphQL queries internally — this is invisible to the caller but means error responses from Braintree are structured differently from REST connectors.
-- **Webhook verification:** Braintree uses HMAC-SHA1 for webhook signature verification. Configure the webhook endpoint in Braintree and store the webhook notification signing key in Hyperswitch.
-- **PayPal parent account requirement:** Braintree is owned by PayPal, and a PayPal Business account is required to activate Braintree. Ensure your PayPal Business account is in good standing before setting up Braintree credentials.
-- **Google Pay and Apple Pay via Braintree:** Both wallets are supported via Braintree's SDK-based integration. Google Pay uses Braintree's Google Pay SDK flow; Apple Pay uses the Braintree Apple Pay SDK flow. These differ from PSP-decryption and Hyperswitch-decryption wallet flows.
-- **Capture methods supported:** Automatic, Manual, SequentialAutomatic.
-- For a full list of supported payment methods, visit [hyperswitch.io/pm-list](https://hyperswitch.io/pm-list).
+<!-- generated from GET /feature_matrix; hyperswitch 4c41905c7d01ddc7ce2b14fc88361d805824a235; host https://sandbox.hyperswitch.io; fetched 2026-09-09; matrix canonical-json-v1 sha256 36360b019f2761dd; 138 connectors.
+     Do not edit by hand. This block regenerates from the connector's
+     SupportedPaymentMethods declaration in code; edit that instead. -->
 
----
+**Integration status:** live
 
-### Activating Braintree via Hyperswitch
+**Category:** payment gateway
 
-#### Prerequisites
+**Webhook flows:** payments, refunds
 
-1. You need to be registered with Braintree. Sign up at [braintreepayments.com/sandbox](https://www.braintreepayments.com/sandbox).
-2. You should have a registered Hyperswitch account, accessible from the [Hyperswitch control center](https://app.hyperswitch.io/register).
-3. The Braintree Merchant ID, Public Key, and Private Key are available in your Braintree dashboard under **Home → Settings → API**.
-4. To set webhooks, navigate to **Home → Settings → API → Webhooks** and create a new webhook.
+| Payment method | Type | Mandates | Refunds | Capture methods | 3DS | Card networks | Countries | Currencies |
+|---|---|---|---|---|---|---|---|---|
+| card | Credit Card | supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Discover, JCB, Mastercard, UnionPay, Visa | 45 ([full list](https://hyperswitch.io/pm-list)) | 134 ([full list](https://hyperswitch.io/pm-list)) |
+| card | Debit Card | supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Discover, JCB, Mastercard, UnionPay, Visa | 45 ([full list](https://hyperswitch.io/pm-list)) | 134 ([full list](https://hyperswitch.io/pm-list)) |
+| wallet | Apple Pay | supported | supported | automatic, manual, sequential automatic | not applicable | - | - | - |
+| wallet | Google Pay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | - | - |
+| wallet | PayPal | not supported | supported | automatic, manual, sequential automatic | not applicable | - | - | - |
 
-[Steps to activate Braintree on the Hyperswitch control center](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch)
+## Configure Braintree
 
----
+Supply the Braintree public key in the API key field and the private key in the API secret field. Hyperswitch combines those values as HTTP Basic credentials for connector requests. The third `SignatureKey` field is accepted by the shared credential shape but is not used by Braintree's authentication conversion.
 
-### Responsibility Boundaries
+The connector sends payment operations through GraphQL. Follow the [connector activation guide](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch) to add these credentials in Hyperswitch.
 
-**Hyperswitch owns:** routing decisions, mandate record storage, retry scheduling, and unified error mapping. **Braintree owns:** payment execution via its GraphQL API, fraud evaluation (Kount integration), and vault storage for payment methods. Braintree's vault is separate from Hyperswitch's vault — payment methods stored in Braintree are referenced by Braintree's nonce/token system, not Hyperswitch's token IDs.
+## Webhooks
 
-**Hyperswitch owns:** translating its unified payment model into Braintree's GraphQL mutation structure. **Braintree owns:** execution and response. If a GraphQL mutation is rejected (e.g. missing required field for a payment method), the error surfaces as a Braintree-level validation error in Hyperswitch's error response — not a network or authentication error.
+Hyperswitch verifies Braintree webhook payloads with HMAC-SHA1. The handler reads the signature and encoded payload from the incoming form body.
 
----
+The implementation recognizes 7 event names:
 
-### Common Failure Modes
+| Braintree event | Hyperswitch effect |
+| --- | --- |
+| `dispute_opened` | `DisputeOpened` |
+| `dispute_lost` | `DisputeLost` |
+| `dispute_won` | `DisputeWon` |
+| `dispute_accepted` | `DisputeAccepted` |
+| `dispute_auto_accepted` | `DisputeAccepted` |
+| `dispute_expired` | `DisputeExpired` |
+| `dispute_disputed` | `DisputeChallenged` |
 
-**Wrong credential type used**
-Symptom: All API calls return authentication errors. Fix: Confirm you are using the Public Key (not the API key or Private Key alone) as the HTTP Basic username, and the Private Key as the password. The Merchant ID is a separate field, not part of the Basic auth credentials.
+Other event names map to `EventNotSupported`.
 
-**PayPal Business account not active**
-Symptom: Braintree account activation fails or payments cannot be processed. Fix: Ensure the PayPal Business account linked to your Braintree account is verified and in good standing.
+## Page gaps
 
-**Webhook signature verification failure**
-Symptom: Braintree webhook events are received but rejected by Hyperswitch — payment statuses do not update. Fix: Verify the webhook signing key configured in Hyperswitch matches the one in your Braintree dashboard under **Settings → API → Webhooks**.
-
-**Google Pay or Apple Pay SDK flow not initialising**
-Symptom: Wallet payment buttons do not appear or fail at initialisation. Fix: Both wallets require Braintree's SDK-based integration. Ensure the correct SDK session token is being generated via Hyperswitch before rendering the wallet button.
-
----
-
-Connector implementation: `crates/hyperswitch_connectors/src/connectors/braintree.rs`.
+- The capability declaration lists payment and refund webhook flows, while the implemented event mapper recognizes dispute events. Confirm the intended declaration before relying on the generated webhook-flow list.
+- Connector source does not declare the vendor dashboard paths for finding credentials or registering the webhook endpoint. Use the current vendor dashboard guidance when completing those steps.

--- a/integration-space/connectors-integrations/available-connectors/braintree.md
+++ b/integration-space/connectors-integrations/available-connectors/braintree.md
@@ -32,7 +32,7 @@ Use this guide to configure credentials and webhook behavior.
 
 ### Configure Braintree
 
-Enter the Braintree public key in the API key field and the private key in the API secret field. Hyperswitch encodes them as HTTP Basic credentials. The shared third credential field is not used for Braintree authentication ([credential mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L215-L237), [request header](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L136-L149)).
+Enter the Braintree public key in the API key field and the private key in the API secret field. Hyperswitch uses the public key as the HTTP Basic username and the private key as the HTTP Basic password. The shared third credential field is not used for Braintree authentication ([credential mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L215-L237), [request header](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L136-L149)).
 
 Follow the [connector activation guide](../activate-connector-on-hyperswitch/README.md) to add these credentials in Hyperswitch. Use Braintree's current dashboard guidance to find the credentials and register the webhook endpoint.
 

--- a/integration-space/connectors-integrations/available-connectors/braintree.md
+++ b/integration-space/connectors-integrations/available-connectors/braintree.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  Connect Braintree to Hyperswitch and review the capabilities declared by the
-  connector implementation.
+  Connect Braintree to Hyperswitch and review the connector setup.
 metaLinks:
   alternates:
     - braintree.md
@@ -9,11 +8,11 @@ metaLinks:
 
 # Braintree
 
-Braintree is a payment gateway integration in Hyperswitch.
+Use this guide to configure credentials and webhook behavior.
 
-## Status and capabilities
+### Status and capabilities
 
-<!-- generated from GET /feature_matrix; hyperswitch 4c41905c7d01ddc7ce2b14fc88361d805824a235; host https://sandbox.hyperswitch.io; fetched 2026-09-09; matrix canonical-json-v1 sha256 36360b019f2761dd; 138 connectors.
+<!-- generated from GET /feature_matrix; hyperswitch 93becbaee4ee3686e1a4d5750d2e547c56c27047; host http://localhost:8080; fetched 2026-09-10; matrix canonical-json-v1 sha256 27951de892af028b; 138 connectors.
      Do not edit by hand. This block regenerates from the connector's
      SupportedPaymentMethods declaration in code; edit that instead. -->
 
@@ -31,31 +30,31 @@ Braintree is a payment gateway integration in Hyperswitch.
 | wallet | Google Pay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | - | - |
 | wallet | PayPal | not supported | supported | automatic, manual, sequential automatic | not applicable | - | - | - |
 
-## Configure Braintree
+### Configure Braintree
 
-Supply the Braintree public key in the API key field and the private key in the API secret field. Hyperswitch combines those values as HTTP Basic credentials for connector requests. The third `SignatureKey` field is accepted by the shared credential shape but is not used by Braintree's authentication conversion.
+Enter the Braintree public key in the API key field and the private key in the API secret field. Hyperswitch encodes them as HTTP Basic credentials. The shared third credential field is not used for Braintree authentication ([credential mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L215-L237), [request header](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L136-L149)).
 
-The connector sends payment operations through GraphQL. Follow the [connector activation guide](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch) to add these credentials in Hyperswitch.
+Follow the [connector activation guide](../activate-connector-on-hyperswitch/README.md) to add these credentials in Hyperswitch. Use Braintree's current dashboard guidance to find the credentials and register the webhook endpoint.
 
-## Webhooks
+### Webhooks
 
-Hyperswitch verifies Braintree webhook payloads with HMAC-SHA1. The handler reads the signature and encoded payload from the incoming form body.
+Hyperswitch verifies Braintree webhook payloads with HMAC-SHA1. The handler reads the signature and encoded payload from the incoming form body ([source](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L983-L1069)).
 
-The implementation recognizes 7 event names:
+The implementation recognizes 7 dispute event names ([source](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L2793-L2802)):
 
 | Braintree event | Hyperswitch effect |
 | --- | --- |
-| `dispute_opened` | `DisputeOpened` |
-| `dispute_lost` | `DisputeLost` |
-| `dispute_won` | `DisputeWon` |
-| `dispute_accepted` | `DisputeAccepted` |
-| `dispute_auto_accepted` | `DisputeAccepted` |
-| `dispute_expired` | `DisputeExpired` |
-| `dispute_disputed` | `DisputeChallenged` |
+| `dispute_opened` | Dispute opened |
+| `dispute_lost` | Dispute lost |
+| `dispute_won` | Dispute won |
+| `dispute_accepted` | Dispute accepted |
+| `dispute_auto_accepted` | Dispute accepted |
+| `dispute_expired` | Dispute expired |
+| `dispute_disputed` | Dispute challenged |
 
-Other event names map to `EventNotSupported`.
+Other event names are not supported.
 
-## Page gaps
+### Page gaps
 
 - The capability declaration lists payment and refund webhook flows, while the implemented event mapper recognizes dispute events. Confirm the intended declaration before relying on the generated webhook-flow list.
-- Connector source does not declare the vendor dashboard paths for finding credentials or registering the webhook endpoint. Use the current vendor dashboard guidance when completing those steps.
+- The connector source does not declare the dashboard paths for finding credentials or registering the webhook endpoint. Use Braintree's current dashboard guidance when completing those steps.


### PR DESCRIPTION
Verdict: content-wrong

## PRs this responds to

- juspay/hyperswitch-docs#229. This in-place update also responds to every open automated review comment on this PR.

## Evidence

- `hyperswitch.origin/main = 93becbaee4ee3686e1a4d5750d2e547c56c27047`
- `hyperswitch-docs.origin/main = d4f18d62f367eea87cecf0f6729efd08ca57690d`
- `hyperswitch-prism.origin/main = 434f9b638dbf3b7e4648f150067be81f16d56af4`
- `matrix.host = http://localhost:8080`, `matrix.fetched = 2026-09-10`, `matrix.connector_count = 138`, and `matrix.canonical-json-v1.sha256 = 27951de892af028b`. The local endpoint builds the response from connector declarations ([matrix construction](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/router/src/routes/feature_matrix.rs#L42-L70)).
- `BRAINTREE.supported_payment_methods.length = 5` and `BRAINTREE.supported_webhook_flows = ["payments", "refunds"]`. The generated block matches the local matrix: 5 rows and 3 header fields ([payment-method declaration](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L1341-L1436), [webhook-flow declaration](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L1438-L1451)).
- `braintree.authentication.shared_third_field_used = false`. The page now describes the public/private-key Basic authentication path without exposing credential values ([credential mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L215-L237), [request header](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L136-L149)).
- `braintree.dispute_event_names.source = 7` and `braintree.dispute_event_names.page = 7`. Every documented name passed an exact-string check against the mapper ([source](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L2793-L2802)).
- The whole-page sweep changed primary section headings to `###`, added source links, used the shared activation guide, and changed the ambiguous sentence to “7 dispute event names” ([updated page](https://github.com/juspay/hyperswitch-docs/blob/docs/braintree-capabilities/integration-space/connectors-integrations/available-connectors/braintree.md)).
- A second visible copy exists under `other-features/connectors/available-connectors/braintree.md`; this PR does not edit it ([legacy copy](https://github.com/juspay/hyperswitch-docs/blob/d4f18d62f367eea87cecf0f6729efd08ca57690d/other-features/connectors/available-connectors/braintree.md)).

## What I could not check

- I could not check this from the sandbox: the current Braintree dashboard paths for finding credentials and registering the webhook endpoint. I checked the connector source and the public Hyperswitch documentation, but those paths are not declared there.

## Decision requested

Approve the regenerated capability block, heading normalization, source-backed authentication and webhook prose, and the explicit note about the webhook-flow declaration versus the dispute mapper.
