### PR TITLE
docs(shift4): refresh capabilities and webhook details

### DIFF
--- a/integration-space/connectors-integrations/available-connectors/shift4.md
+++ b/integration-space/connectors-integrations/available-connectors/shift4.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  Connect Shift4 to Hyperswitch and review the capabilities declared by the
-  connector implementation.
+  Connect Shift4 to Hyperswitch and review the connector setup.
 metaLinks:
   alternates:
     - shift4.md
@@ -9,11 +8,11 @@ metaLinks:
 
 # Shift4
 
-Shift4 is a payment gateway integration in Hyperswitch.
+Use this guide to configure credentials and webhook behavior.
 
-## Status and capabilities
+### Status and capabilities
 
-<!-- generated from GET /feature_matrix; hyperswitch 4c41905c7d01ddc7ce2b14fc88361d805824a235; host https://sandbox.hyperswitch.io; fetched 2026-09-09; matrix canonical-json-v1 sha256 36360b019f2761dd; 138 connectors.
+<!-- generated from GET /feature_matrix; hyperswitch 93becbaee4ee3686e1a4d5750d2e547c56c27047; host http://localhost:8080; fetched 2026-09-10; matrix canonical-json-v1 sha256 27951de892af028b; 138 connectors.
      Do not edit by hand. This block regenerates from the connector's
      SupportedPaymentMethods declaration in code; edit that instead. -->
 
@@ -32,28 +31,23 @@ Shift4 is a payment gateway integration in Hyperswitch.
 | card | Credit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | Mastercard, Visa | 247 ([full list](https://hyperswitch.io/pm-list)) | 154 ([full list](https://hyperswitch.io/pm-list)) |
 | card | Debit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | Mastercard, Visa | 247 ([full list](https://hyperswitch.io/pm-list)) | 154 ([full list](https://hyperswitch.io/pm-list)) |
 
-## Configure Shift4
+### Configure Shift4
 
-Supply the Shift4 API key in the API key field. Hyperswitch appends a colon to the API key, Base64-encodes the result, and sends it in the Authorization header. Enter the raw API key in Hyperswitch rather than an already encoded value.
+Enter the raw Shift4 API key in the API key field. Hyperswitch appends a colon, Base64-encodes the result, and sends it as an HTTP Basic credential ([credential mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs#L835-L850), [request header](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4.rs#L112-L126)).
 
-Follow the [connector activation guide](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch) to add the credential in Hyperswitch.
+Follow the [connector activation guide](../activate-connector-on-hyperswitch/README.md) to add the credential in Hyperswitch. Use Shift4's current dashboard guidance to find the API key and register the webhook endpoint.
 
-## Webhooks
+### Webhooks
 
-The webhook enum contains 6 exact variants. Five variants represent mapped events, and `Unknown` is the catch-all:
+Register the Hyperswitch endpoint in Shift4 using the [standard webhook setup instructions](https://docs.hyperswitch.io/integration-guide/webhooks). The Shift4 connector does not implement a connector-specific source-verification method, so apply verification controls before enabling incoming events ([webhook implementation](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4.rs#L934-L990)).
 
-| Shift4 event variant | Hyperswitch event |
+The source enum contains 6 exact variants. Five variants map the wire values below, and the sixth is a catch-all for any other value. The enum applies `SCREAMING_SNAKE_CASE` to incoming values ([enum](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs#L883-L899), [mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs#L1239-L1250)):
+
+| Shift4 event | Hyperswitch effect |
 | --- | --- |
-| `ChargeSucceeded` | `PaymentIntentProcessing` |
-| `ChargeUpdated` | `PaymentIntentProcessing` |
-| `ChargeCaptured` | `PaymentIntentSuccess` |
-| `ChargeFailed` | `PaymentIntentFailure` |
-| `ChargeRefunded` | `RefundSuccess` |
-| `Unknown` | `EventNotSupported` |
-
-The enum applies the `SCREAMING_SNAKE_CASE` serde rename rule to incoming values.
-
-## Page gaps
-
-- The connector does not define a connector-specific webhook source-verification method. Confirm the required verification controls before enabling incoming events.
-- Connector source does not declare the vendor dashboard paths for finding the API key or registering the webhook endpoint. Use the current vendor dashboard guidance when completing those steps.
+| `CHARGE_SUCCEEDED` | Payment processing |
+| `CHARGE_UPDATED` | Payment processing |
+| `CHARGE_CAPTURED` | Payment succeeded |
+| `CHARGE_FAILED` | Payment failed |
+| `CHARGE_REFUNDED` | Refund succeeded |
+| Any other value | Event not supported |

--- a/integration-space/connectors-integrations/available-connectors/shift4.md
+++ b/integration-space/connectors-integrations/available-connectors/shift4.md
@@ -1,5 +1,7 @@
 ---
-description: Accept payments through Shift4 via Juspay Hyperswitch
+description: >-
+  Connect Shift4 to Hyperswitch and review the capabilities declared by the
+  connector implementation.
 metaLinks:
   alternates:
     - shift4.md
@@ -7,48 +9,51 @@ metaLinks:
 
 # Shift4
 
-Shift4 connects to Hyperswitch as a `PaymentGateway` connector using `HeaderKey` authentication with a Base64-encoded API key. Unlike connectors that use a plain Bearer token, Shift4 uses HTTP Basic auth format: the API key is Base64-encoded as `{api_key}:` (with a trailing colon and empty password field) and sent as `Authorization: Basic {base64_encoded_key}`. All requests use `application/json`.
+Shift4 is a payment gateway integration in Hyperswitch.
 
-### Connector-Specific Notes
+## Status and capabilities
 
-- **HTTP Basic auth format:** Shift4's API key is Base64-encoded in HTTP Basic format (`{api_key}:`) — the empty string after the colon is intentional. This is functionally an API key auth, but the encoding and header format follow the HTTP Basic auth convention. The API key is found in your Shift4 dashboard on the Home page.
-- **Capture methods supported:** Automatic, Manual, SequentialAutomatic.
-- **SetupMandate:** Supported for applicable payment methods.
-- Shift4 provides payment processing with a focus on hospitality, retail, and restaurant verticals, in addition to e-commerce.
-- Payment methods must be enabled in both Hyperswitch and your Shift4 dashboard to function correctly.
-- For a full list of supported payment methods, visit [hyperswitch.io/pm-list](https://hyperswitch.io/pm-list).
+<!-- generated from GET /feature_matrix; hyperswitch 4c41905c7d01ddc7ce2b14fc88361d805824a235; host https://sandbox.hyperswitch.io; fetched 2026-09-09; matrix canonical-json-v1 sha256 36360b019f2761dd; 138 connectors.
+     Do not edit by hand. This block regenerates from the connector's
+     SupportedPaymentMethods declaration in code; edit that instead. -->
 
----
+**Integration status:** live
 
-### Activating Shift4 via Hyperswitch
+**Category:** payment gateway
 
-#### Prerequisites
+**Webhook flows:** payments, refunds
 
-1. You need to be registered with Shift4. Sign up at [shift4.com](https://www.shift4.com/).
-2. You should have a registered Hyperswitch account, accessible from the [Hyperswitch control center](https://app.hyperswitch.io/).
-3. The Shift4 API key is found on the Home page of your Shift4 dashboard.
-4. Select all payment methods you wish to use Shift4 for. Ensure these match the ones configured in your Shift4 dashboard.
+| Payment method | Type | Mandates | Refunds | Capture methods | 3DS | Card networks | Countries | Currencies |
+|---|---|---|---|---|---|---|---|---|
+| bank redirect | EPS | not supported | supported | automatic, manual, sequential automatic | not applicable | - | AUT | EUR |
+| bank redirect | Giropay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | DEU | EUR |
+| bank redirect | iDEAL | not supported | supported | automatic, manual, sequential automatic | not applicable | - | NLD | EUR |
+| bank redirect | Sofort | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 12 ([full list](https://hyperswitch.io/pm-list)) | CHF, EUR |
+| card | Credit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | Mastercard, Visa | 247 ([full list](https://hyperswitch.io/pm-list)) | 154 ([full list](https://hyperswitch.io/pm-list)) |
+| card | Debit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | Mastercard, Visa | 247 ([full list](https://hyperswitch.io/pm-list)) | 154 ([full list](https://hyperswitch.io/pm-list)) |
 
-[Steps to activate Shift4 on the Hyperswitch control center](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch)
+## Configure Shift4
 
----
+Supply the Shift4 API key in the API key field. Hyperswitch appends a colon to the API key, Base64-encodes the result, and sends it in the Authorization header. Enter the raw API key in Hyperswitch rather than an already encoded value.
 
-### Responsibility Boundaries
+Follow the [connector activation guide](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch) to add the credential in Hyperswitch.
 
-**Hyperswitch owns:** routing decisions, retry scheduling, mandate record storage, Base64-encoding the API key into HTTP Basic format on every request, and unified error mapping. **Shift4 owns:** payment execution, fraud decisioning, and terminal/POS routing for in-person payment scenarios. Shift4's POS routing logic is entirely within Shift4's system — Hyperswitch only interacts with Shift4's online payment API.
+## Webhooks
 
-**Hyperswitch owns:** constructing the correct Base64-encoded Authorization header. **Shift4 owns:** validating the decoded API key. If the API key changes in Shift4 and is not updated in Hyperswitch, all requests will fail authentication.
+The webhook enum contains 6 exact variants. Five variants represent mapped events, and `Unknown` is the catch-all:
 
----
+| Shift4 event variant | Hyperswitch event |
+| --- | --- |
+| `ChargeSucceeded` | `PaymentIntentProcessing` |
+| `ChargeUpdated` | `PaymentIntentProcessing` |
+| `ChargeCaptured` | `PaymentIntentSuccess` |
+| `ChargeFailed` | `PaymentIntentFailure` |
+| `ChargeRefunded` | `RefundSuccess` |
+| `Unknown` | `EventNotSupported` |
 
-### Common Failure Modes
+The enum applies the `SCREAMING_SNAKE_CASE` serde rename rule to incoming values.
 
-**Authentication failure due to encoding error**
-Symptom: All requests return an authentication error from Shift4. Fix: Verify the API key in Hyperswitch is the raw key from your Shift4 dashboard — Hyperswitch handles the Base64 encoding automatically. Do not manually Base64-encode the key before entering it in the control center.
+## Page gaps
 
-**Payment method not configured in Shift4**
-Symptom: A payment method fails with an availability error. Fix: Verify the method is enabled in your Shift4 account and matches the selection in the Hyperswitch connector configuration.
-
----
-
-Connector implementation: `crates/hyperswitch_connectors/src/connectors/shift4.rs`.
+- The connector does not define a connector-specific webhook source-verification method. Confirm the required verification controls before enabling incoming events.
+- Connector source does not declare the vendor dashboard paths for finding the API key or registering the webhook endpoint. Use the current vendor dashboard guidance when completing those steps.


### PR DESCRIPTION
Verdict: content-wrong

## PRs this responds to

- juspay/hyperswitch-docs#230. This in-place update also responds to every open automated review comment on this PR.

## Evidence

- `hyperswitch.origin/main = 93becbaee4ee3686e1a4d5750d2e547c56c27047`
- `hyperswitch-docs.origin/main = d4f18d62f367eea87cecf0f6729efd08ca57690d`
- `hyperswitch-prism.origin/main = 434f9b638dbf3b7e4648f150067be81f16d56af4`
- `matrix.host = http://localhost:8080`, `matrix.fetched = 2026-09-10`, `matrix.connector_count = 138`, and `matrix.canonical-json-v1.sha256 = 27951de892af028b`. The local endpoint builds the response from connector declarations ([matrix construction](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/router/src/routes/feature_matrix.rs#L42-L70)).
- `SHIFT4.supported_payment_methods.length = 6` and `SHIFT4.supported_webhook_flows = ["payments", "refunds"]`. The generated block matches the local matrix: 6 rows and 3 header fields ([payment-method declaration](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4.rs#L992-L1096), [webhook-flow declaration](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4.rs#L1098-L1126)).
- `shift4.webhook_enum.variants = 6`, `shift4.webhook_enum.mapped_wire_values = 5`, and `shift4.webhook_enum.catch_all = 1`. The five wire literals were derived with the declared `SCREAMING_SNAKE_CASE` rule and checked against the page ([enum](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs#L883-L899), [mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs#L1239-L1250)). The explicit counts remain as source-drift checks.
- `shift4.connector_specific_source_verification_method_count = 0`. The page now links to the standard webhook setup instructions and warns readers to apply verification controls ([webhook implementation](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4.rs#L934-L990)). The setup URL returned HTTP 200, its title was `Webhooks | Hyperswitch`, and `SUMMARY.md` contains the navigation entry ([setup page](https://docs.hyperswitch.io/integration-guide/webhooks)).
- The whole-page sweep changed primary section headings to `###`, added source links, used the shared activation guide, and removed the rendered `Page gaps` section ([updated page](https://github.com/juspay/hyperswitch-docs/blob/docs/shift4-capabilities/integration-space/connectors-integrations/available-connectors/shift4.md)).
- A second visible copy exists under `other-features/connectors/available-connectors/shift4.md`; this PR does not edit it ([legacy copy](https://github.com/juspay/hyperswitch-docs/blob/d4f18d62f367eea87cecf0f6729efd08ca57690d/other-features/connectors/available-connectors/shift4.md)).

## What I could not check

- I could not check this from the sandbox: the current Shift4 dashboard paths for finding the API key and registering the webhook endpoint. I checked the connector source and the public Hyperswitch documentation, but those paths are not declared there.
- The connector-specific source-verification method remains absent. This is kept in the PR description rather than rendered as `Page gaps` content.

## Decision requested

Approve the regenerated capability block, heading normalization, retained source-drift counts, standard webhook setup link, and removal of rendered review notes.
