### PR TITLE
docs(nuvei): refresh capabilities and webhook details

### DIFF
--- a/integration-space/connectors-integrations/available-connectors/nuvei.md
+++ b/integration-space/connectors-integrations/available-connectors/nuvei.md
@@ -1,7 +1,6 @@
 ---
 description: >-
-  Connect Nuvei to Hyperswitch and review the capabilities declared by the
-  connector implementation.
+  Connect Nuvei to Hyperswitch and review the connector setup.
 metaLinks:
   alternates:
     - nuvei.md
@@ -9,11 +8,11 @@ metaLinks:
 
 # Nuvei
 
-Nuvei is a payment gateway integration in Hyperswitch.
+Use this guide to configure credentials and webhook behavior.
 
-## Status and capabilities
+### Status and capabilities
 
-<!-- generated from GET /feature_matrix; hyperswitch 4c41905c7d01ddc7ce2b14fc88361d805824a235; host https://sandbox.hyperswitch.io; fetched 2026-09-09; matrix canonical-json-v1 sha256 36360b019f2761dd; 138 connectors.
+<!-- generated from GET /feature_matrix; hyperswitch 93becbaee4ee3686e1a4d5750d2e547c56c27047; host http://localhost:8080; fetched 2026-09-10; matrix canonical-json-v1 sha256 27951de892af028b; 138 connectors.
      Do not edit by hand. This block regenerates from the connector's
      SupportedPaymentMethods declaration in code; edit that instead. -->
 
@@ -38,75 +37,69 @@ Nuvei is a payment gateway integration in Hyperswitch.
 | wallet | Google Pay | supported | supported | automatic, manual, sequential automatic | not applicable | - | 237 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
 | wallet | PayPal | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 10 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
 
-## Configure Nuvei
+### Configure Nuvei
 
-Supply the merchant ID in the API key field, the merchant site ID in the `key1` field, and the merchant secret in the API secret field. Nuvei requests do not use an Authorization header. The connector includes the authentication values and request checksum in the request body.
+Enter the merchant ID in the API key field, the merchant site ID in the `key1` field, and the merchant secret in the API secret field. Nuvei requests do not use an Authorization header. The connector places the authentication values and request checksum in the request body ([credential mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L1734-L1757), [empty auth header](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L127-L133)).
 
-Follow the [connector activation guide](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch) to add these credentials in Hyperswitch.
+Follow the [connector activation guide](../activate-connector-on-hyperswitch/README.md) to add these credentials in Hyperswitch. Use Nuvei's current dashboard guidance to find the credentials and register webhook endpoints.
 
-## Webhooks
+### Webhooks
 
-For payment direct merchant notifications, Hyperswitch verifies the advanced response checksum with SHA-256.
+For payment direct merchant notifications, Hyperswitch verifies the advanced response checksum with SHA-256 ([source](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L1311-L1369)). Chargeback notifications use a checksum header, but the source marks the verification-message format as a placeholder. Confirm that format before enabling chargeback notifications ([source](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L1371-L1378)).
 
-### Payment and refund events
+#### Payment and refund events
 
-The payment mapper contains 11 branches covering the following status and transaction-type combinations. `DmnStatus` applies an `UPPERCASE` serde rename rule to incoming status values:
-
-| Nuvei status | Transaction type | Hyperswitch effect |
-| --- | --- | --- |
-| `Success` or `Approved` | `Auth` | `PaymentIntentAuthorizationSuccess` |
-| `Success` or `Approved` | `Sale` | `PaymentIntentSuccess` |
-| `Success` or `Approved` | `Settle` | `PaymentIntentCaptureSuccess` |
-| `Success` or `Approved` | `Void` | `PaymentIntentCancelled` |
-| `Success` or `Approved` | `Credit` | `RefundSuccess` |
-| `Error` or `Declined` | `Auth` | `PaymentIntentAuthorizationFailure` |
-| `Error` or `Declined` | `Sale` | `PaymentIntentFailure` |
-| `Error` or `Declined` | `Settle` | `PaymentIntentCaptureFailure` |
-| `Error` or `Declined` | `Void` | `PaymentIntentCancelFailure` |
-| `Error` or `Declined` | `Credit` | `RefundFailure` |
-| `Pending` | `Auth`, `Sale`, or `Settle` | `PaymentIntentProcessing` |
-
-Other payment combinations return `WebhookEventTypeNotFound`.
-
-### Payout events
-
-When the payouts feature is enabled and the client request identifier has the payout prefix, the implementation uses 3 mapping branches:
+The payment mapper contains 11 branches for the combinations below. Incoming `DmnStatus` values are uppercase because the enum applies `#[serde(rename_all = "UPPERCASE")]` ([status enum](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3434-L3443), [mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3634-L3675)):
 
 | Nuvei status | Transaction type | Hyperswitch effect |
 | --- | --- | --- |
-| `Success` or `Approved` | `Credit` | `PayoutSuccess` |
-| `Pending` | Any declared transaction type | `PayoutProcessing` |
-| `Declined` or `Error` | Any declared transaction type | `PayoutFailure` |
+| `SUCCESS` or `APPROVED` | `Auth` | Authorization succeeded |
+| `SUCCESS` or `APPROVED` | `Sale` | Payment succeeded |
+| `SUCCESS` or `APPROVED` | `Settle` | Capture succeeded |
+| `SUCCESS` or `APPROVED` | `Void` | Payment canceled |
+| `SUCCESS` or `APPROVED` | `Credit` | Refund succeeded |
+| `ERROR` or `DECLINED` | `Auth` | Authorization failed |
+| `ERROR` or `DECLINED` | `Sale` | Payment failed |
+| `ERROR` or `DECLINED` | `Settle` | Capture failed |
+| `ERROR` or `DECLINED` | `Void` | Cancellation failed |
+| `ERROR` or `DECLINED` | `Credit` | Refund failed |
+| `PENDING` | `Auth`, `Sale`, or `Settle` | Payment processing |
 
-Other payout combinations return `WebhookEventTypeNotFound`.
+Other payment combinations are not supported.
 
-### Dispute events
+#### Payout events
 
-The dispute enum defines 51 exact event codes. The table accounts for all 51:
+When payouts are enabled and the client request identifier has the payout prefix, the implementation uses 3 mapping branches ([source](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3678-L3693)):
+
+| Nuvei status | Transaction type | Hyperswitch effect |
+| --- | --- | --- |
+| `SUCCESS` or `APPROVED` | `Credit` | Payout succeeded |
+| `PENDING` | Any declared transaction type | Payout processing |
+| `DECLINED` or `ERROR` | Any declared transaction type | Payout failed |
+
+Other payout combinations are not supported.
+
+#### Dispute events
+
+The dispute enum defines 51 exact event codes. The table accounts for all 51 ([event codes](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3247-L3400), [mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3710-L3816)):
 
 | Hyperswitch effect | Nuvei event codes |
 | --- | --- |
-| `DisputeOpened` | `FC`, `CC`, `MCC`, `FC-CLSD-RCL`, `INQ` |
-| `DisputeAccepted` | `CC-A-ACPT`, `FC-A-ACPT`, `FC-A-ACPT-MCOLL`, `FC-M-ACPT`, `FC-SPCSE`, `RDR`, `MCC-M-ACPT`, `MCC-A-ACPT`, `INQ-M-RFND`, `IPA-M-ACPT`, `IPA-M-PART`, `IPA-A-ACPT`, `IPAR-M-ACPT`, `IPAR-A-ACPT` |
-| `DisputeLost` | `FC-A-EPRD`, `FC-M-PART`, `FC-CLSD-CHF`, `PA-CLSD-CHF`, `MCC-CLSD-CHF` |
-| `DisputeChallenged` | `FC-M-RJCT`, `FC-A-RJCT`, `IPA`, `MPA-I-RJCT`, `INQ-M-RSP`, `IPA-M-RJCT` |
-| `DisputeExpired` | `FC-A-RJCT-EXP`, `FC-M-PART-EXP`, `FC-M-RJCT-EXP`, `MCC-EXPR`, `INQ-EXPR`, `IPA-M-PART-EXP`, `IPA-M-RJCT-EXP` |
-| `DisputeWon` | `MPA-I-ACPT`, `MPA-I-PART`, `FC-CLSD-MF`, `MCC-CLSD-MF`, `PA-CLSD-MF` |
-| `DisputeCancelled` | `FC-I-RCL`, `INQ-A-CNLD`, `PA-CLSD-RC`, `CC-I-RCLL` |
+| Dispute opened | `FC`, `CC`, `MCC`, `FC-CLSD-RCL`, `INQ` |
+| Dispute accepted | `CC-A-ACPT`, `FC-A-ACPT`, `FC-A-ACPT-MCOLL`, `FC-M-ACPT`, `FC-SPCSE`, `RDR`, `MCC-M-ACPT`, `MCC-A-ACPT`, `INQ-M-RFND`, `IPA-M-ACPT`, `IPA-M-PART`, `IPA-A-ACPT`, `IPAR-M-ACPT`, `IPAR-A-ACPT` |
+| Dispute lost | `FC-A-EPRD`, `FC-M-PART`, `FC-CLSD-CHF`, `PA-CLSD-CHF`, `MCC-CLSD-CHF` |
+| Dispute challenged | `FC-M-RJCT`, `FC-A-RJCT`, `IPA`, `MPA-I-RJCT`, `INQ-M-RSP`, `IPA-M-RJCT` |
+| Dispute expired | `FC-A-RJCT-EXP`, `FC-M-PART-EXP`, `FC-M-RJCT-EXP`, `MCC-EXPR`, `INQ-EXPR`, `IPA-M-PART-EXP`, `IPA-M-RJCT-EXP` |
+| Dispute won | `MPA-I-ACPT`, `MPA-I-PART`, `FC-CLSD-MF`, `MCC-CLSD-MF`, `PA-CLSD-MF` |
+| Dispute canceled | `FC-I-RCL`, `INQ-A-CNLD`, `PA-CLSD-RC`, `CC-I-RCLL` |
 | No direct event; category fallback may apply | `MCC-A-RJCT`, `MCC-M-RJCT`, `INQ-A-RJCT`, `INQ-M-P-RFND`, `INQ-UPD` |
 
-The category fallback defines 5 exact category values:
+The category fallback defines 5 exact values ([source](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3420-L3431)):
 
 | Chargeback category | Hyperswitch effect |
 | --- | --- |
-| `cancelled` | `DisputeCancelled` |
-| `Duplicate` | `DisputeCancelled` |
-| `RDR-Refund` | `DisputeAccepted` |
+| `cancelled` | Dispute canceled |
+| `Duplicate` | Dispute canceled |
+| `RDR-Refund` | Dispute accepted |
 | `Regular` | No fallback event |
 | `Soft_CB` | No fallback event |
-
-## Page gaps
-
-- The capability declaration lists payment and dispute webhook flows, while the event mapper also contains refund and feature-gated payout outcomes. Confirm the intended declaration before relying on the generated webhook-flow list.
-- Chargeback source verification reads a checksum header, but the source marks its verification-message format as a placeholder. Confirm that format before enabling chargeback notifications.
-- Connector source does not declare the vendor dashboard paths for finding credentials or registering webhook endpoints. Use the current vendor dashboard guidance when completing those steps.

--- a/integration-space/connectors-integrations/available-connectors/nuvei.md
+++ b/integration-space/connectors-integrations/available-connectors/nuvei.md
@@ -1,8 +1,7 @@
 ---
 description: >-
-  Connect Nuvei to Juspay Hyperswitch to accept payments globally across
-  e-commerce and high-growth industries using Nuvei's payment processing and
-  acquiring services.
+  Connect Nuvei to Hyperswitch and review the capabilities declared by the
+  connector implementation.
 metaLinks:
   alternates:
     - nuvei.md
@@ -10,51 +9,104 @@ metaLinks:
 
 # Nuvei
 
-<div align="left"><img src="https://hyperswitch.io/icons/homePageIcons/logos/nuveiLogo.svg" alt=""></div>
+Nuvei is a payment gateway integration in Hyperswitch.
 
-Nuvei connects to Hyperswitch as a `PaymentGateway` connector using `SignatureKey` authentication — API key, site ID, and secret key are combined with a SHA-256 request signature. Unlike Bearer token connectors, Nuvei validates each request using a signature computed from the request parameters and the secret key, included in the request body. All requests use `application/json`. Nuvei also supports payouts through Hyperswitch's unified payouts interface.
+## Status and capabilities
 
-### Connector-Specific Notes
+<!-- generated from GET /feature_matrix; hyperswitch 4c41905c7d01ddc7ce2b14fc88361d805824a235; host https://sandbox.hyperswitch.io; fetched 2026-09-09; matrix canonical-json-v1 sha256 36360b019f2761dd; 138 connectors.
+     Do not edit by hand. This block regenerates from the connector's
+     SupportedPaymentMethods declaration in code; edit that instead. -->
 
-* **Request-level signature:** Nuvei does not use a static Bearer token for auth. Each request includes a SHA-256 signature computed from the concatenation of specific request fields and the secret key. The API key and site ID are also required. All three credentials are needed to construct valid requests.
-* **Credentials location:** The Nuvei API key is found in your Nuvei dashboard under **Settings → My Account → Account Details**.
-* **Payouts:** Nuvei supports payout fulfillment through Hyperswitch's unified payouts interface.
-* **Capture methods supported:** Automatic, Manual, SequentialAutomatic.
-* **SetupMandate:** Supported for applicable payment methods.
-* Payment methods must be enabled in both Hyperswitch and your Nuvei dashboard — a mismatch is the most common source of payment failures.
-* For a full list of supported payment methods, visit [hyperswitch.io/pm-list](https://hyperswitch.io/pm-list).
+**Integration status:** live
 
-***
+**Category:** payment gateway
 
-### Activating Nuvei via Hyperswitch
+**Webhook flows:** disputes, payments
 
-#### Prerequisites
+| Payment method | Type | Mandates | Refunds | Capture methods | 3DS | Card networks | Countries | Currencies |
+|---|---|---|---|---|---|---|---|---|
+| bank redirect | EPS | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 10 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
+| bank redirect | Giropay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | - | EUR |
+| bank redirect | iDEAL | not supported | supported | automatic, manual, sequential automatic | not applicable | - | - | EUR |
+| bank redirect | Sofort | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 10 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
+| card | Credit Card | supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Cartes Bancaires, Diners Club, Discover, Interac, JCB, Mastercard, UnionPay, Visa | 249 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
+| card | Debit Card | supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Cartes Bancaires, Diners Club, Discover, Interac, JCB, Mastercard, UnionPay, Visa | 249 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
+| network token | Network Token | supported | supported | automatic, manual, sequential automatic | not applicable | - | - | - |
+| pay later | Afterpay Clearpay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 10 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
+| pay later | Klarna | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 10 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
+| wallet | Apple Pay | supported | supported | automatic, manual, sequential automatic | not applicable | - | 59 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
+| wallet | Google Pay | supported | supported | automatic, manual, sequential automatic | not applicable | - | 237 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
+| wallet | PayPal | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 10 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
 
-1. You need to be registered with Nuvei. Sign up at [nuvei.com](https://nuvei.com/).
-2. You should have a registered Hyperswitch account, accessible from the [Hyperswitch control center](https://app.hyperswitch.io/).
-3. The Nuvei API key is found in your Nuvei dashboard under **Settings → My Account → Account Details**.
-4. Select all payment methods you wish to use Nuvei for. Ensure these match the ones configured in your Nuvei dashboard.
+## Configure Nuvei
 
-[Steps to activate Nuvei on the Hyperswitch control center](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch)
+Supply the merchant ID in the API key field, the merchant site ID in the `key1` field, and the merchant secret in the API secret field. Nuvei requests do not use an Authorization header. The connector includes the authentication values and request checksum in the request body.
 
-***
+Follow the [connector activation guide](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch) to add these credentials in Hyperswitch.
 
-### Responsibility Boundaries
+## Webhooks
 
-**Hyperswitch owns:** routing decisions, retry scheduling, mandate record storage, request signature computation, and unified error mapping. **Nuvei owns:** payment execution, fraud scoring, payout disbursement, and the signature validation logic that authenticates each request.
+For payment direct merchant notifications, Hyperswitch verifies the advanced response checksum with SHA-256.
 
-**Hyperswitch owns:** computing the correct SHA-256 signature for every request. **Nuvei owns:** validating it. If the secret key changes in Nuvei and is not updated in Hyperswitch, all requests will fail Nuvei's signature validation.
+### Payment and refund events
 
-***
+The payment mapper contains 11 branches covering the following status and transaction-type combinations. `DmnStatus` applies an `UPPERCASE` serde rename rule to incoming status values:
 
-### Common Failure Modes
+| Nuvei status | Transaction type | Hyperswitch effect |
+| --- | --- | --- |
+| `Success` or `Approved` | `Auth` | `PaymentIntentAuthorizationSuccess` |
+| `Success` or `Approved` | `Sale` | `PaymentIntentSuccess` |
+| `Success` or `Approved` | `Settle` | `PaymentIntentCaptureSuccess` |
+| `Success` or `Approved` | `Void` | `PaymentIntentCancelled` |
+| `Success` or `Approved` | `Credit` | `RefundSuccess` |
+| `Error` or `Declined` | `Auth` | `PaymentIntentAuthorizationFailure` |
+| `Error` or `Declined` | `Sale` | `PaymentIntentFailure` |
+| `Error` or `Declined` | `Settle` | `PaymentIntentCaptureFailure` |
+| `Error` or `Declined` | `Void` | `PaymentIntentCancelFailure` |
+| `Error` or `Declined` | `Credit` | `RefundFailure` |
+| `Pending` | `Auth`, `Sale`, or `Settle` | `PaymentIntentProcessing` |
 
-**Signature validation failure** Symptom: All requests return a Nuvei authentication or signature error. Fix: Verify that all three credentials (API key, site ID, secret key) in Hyperswitch exactly match those in your Nuvei account. Any mismatch causes the computed signature to fail validation.
+Other payment combinations return `WebhookEventTypeNotFound`.
 
-**Payment method not enabled** Symptom: A payment method selected in Hyperswitch fails with a method availability error from Nuvei. Fix: Verify the method is enabled in your Nuvei account configuration and matches the selection in Hyperswitch.
+### Payout events
 
-**Payout failure** Symptom: Payout fulfillment fails at Nuvei. Fix: Ensure all required recipient and payout details are populated before initiating the payout through Hyperswitch.
+When the payouts feature is enabled and the client request identifier has the payout prefix, the implementation uses 3 mapping branches:
 
-***
+| Nuvei status | Transaction type | Hyperswitch effect |
+| --- | --- | --- |
+| `Success` or `Approved` | `Credit` | `PayoutSuccess` |
+| `Pending` | Any declared transaction type | `PayoutProcessing` |
+| `Declined` or `Error` | Any declared transaction type | `PayoutFailure` |
 
-Connector implementation: `crates/hyperswitch_connectors/src/connectors/nuvei.rs`.
+Other payout combinations return `WebhookEventTypeNotFound`.
+
+### Dispute events
+
+The dispute enum defines 51 exact event codes. The table accounts for all 51:
+
+| Hyperswitch effect | Nuvei event codes |
+| --- | --- |
+| `DisputeOpened` | `FC`, `CC`, `MCC`, `FC-CLSD-RCL`, `INQ` |
+| `DisputeAccepted` | `CC-A-ACPT`, `FC-A-ACPT`, `FC-A-ACPT-MCOLL`, `FC-M-ACPT`, `FC-SPCSE`, `RDR`, `MCC-M-ACPT`, `MCC-A-ACPT`, `INQ-M-RFND`, `IPA-M-ACPT`, `IPA-M-PART`, `IPA-A-ACPT`, `IPAR-M-ACPT`, `IPAR-A-ACPT` |
+| `DisputeLost` | `FC-A-EPRD`, `FC-M-PART`, `FC-CLSD-CHF`, `PA-CLSD-CHF`, `MCC-CLSD-CHF` |
+| `DisputeChallenged` | `FC-M-RJCT`, `FC-A-RJCT`, `IPA`, `MPA-I-RJCT`, `INQ-M-RSP`, `IPA-M-RJCT` |
+| `DisputeExpired` | `FC-A-RJCT-EXP`, `FC-M-PART-EXP`, `FC-M-RJCT-EXP`, `MCC-EXPR`, `INQ-EXPR`, `IPA-M-PART-EXP`, `IPA-M-RJCT-EXP` |
+| `DisputeWon` | `MPA-I-ACPT`, `MPA-I-PART`, `FC-CLSD-MF`, `MCC-CLSD-MF`, `PA-CLSD-MF` |
+| `DisputeCancelled` | `FC-I-RCL`, `INQ-A-CNLD`, `PA-CLSD-RC`, `CC-I-RCLL` |
+| No direct event; category fallback may apply | `MCC-A-RJCT`, `MCC-M-RJCT`, `INQ-A-RJCT`, `INQ-M-P-RFND`, `INQ-UPD` |
+
+The category fallback defines 5 exact category values:
+
+| Chargeback category | Hyperswitch effect |
+| --- | --- |
+| `cancelled` | `DisputeCancelled` |
+| `Duplicate` | `DisputeCancelled` |
+| `RDR-Refund` | `DisputeAccepted` |
+| `Regular` | No fallback event |
+| `Soft_CB` | No fallback event |
+
+## Page gaps
+
+- The capability declaration lists payment and dispute webhook flows, while the event mapper also contains refund and feature-gated payout outcomes. Confirm the intended declaration before relying on the generated webhook-flow list.
+- Chargeback source verification reads a checksum header, but the source marks its verification-message format as a placeholder. Confirm that format before enabling chargeback notifications.
+- Connector source does not declare the vendor dashboard paths for finding credentials or registering webhook endpoints. Use the current vendor dashboard guidance when completing those steps.


### PR DESCRIPTION
Verdict: content-wrong

## PRs this responds to

- juspay/hyperswitch-docs#231. This in-place update also responds to every open automated review comment on this PR.

## Evidence

- `hyperswitch.origin/main = 93becbaee4ee3686e1a4d5750d2e547c56c27047`
- `hyperswitch-docs.origin/main = d4f18d62f367eea87cecf0f6729efd08ca57690d`
- `hyperswitch-prism.origin/main = 434f9b638dbf3b7e4648f150067be81f16d56af4`
- `matrix.host = http://localhost:8080`, `matrix.fetched = 2026-09-10`, `matrix.connector_count = 138`, and `matrix.canonical-json-v1.sha256 = 27951de892af028b`. The local endpoint builds the response from connector declarations ([matrix construction](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/router/src/routes/feature_matrix.rs#L42-L70)).
- `NUVEI.supported_payment_methods.length = 12` and `NUVEI.supported_webhook_flows = ["payments", "disputes"]`. The generated block matches the local matrix: 12 rows and 3 header fields ([payment-method declaration](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L1624-L1791), [webhook-flow declaration](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L1793-L1823)).
- `nuvei.DmnStatus.rename_all = "UPPERCASE"` and `nuvei.DmnStatus.variants = 5`. Every payment and payout status literal is now uppercase, and the page cites the exact serde attribute ([status enum](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3434-L3443)).
- `nuvei.payment_mapper.branches = 11`, `nuvei.payout_mapper.branches = 3`, `nuvei.dispute_codes.source = 51`, `nuvei.dispute_codes.page = 51`, `nuvei.dispute_codes.missing = 0`, `nuvei.dispute_codes.extra = 0`, `nuvei.chargeback_categories.source = 5`, and `nuvei.chargeback_categories.page = 5`. The page lists passed exact-string and count checks against the source ([payment mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3634-L3675), [payout mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3678-L3693), [dispute codes](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3247-L3400), [dispute mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3710-L3816), [category values](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3420-L3431)).
- `nuvei.chargeback_verification_message = "TODO: Need to figure out"`. The page warns that chargeback verification-message construction is still a source placeholder ([source](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L1371-L1378)).
- The whole-page sweep changed primary section headings to `###`, added source links, used the shared activation guide, and removed the rendered `Page gaps` section ([updated page](https://github.com/juspay/hyperswitch-docs/blob/docs/nuvei-capabilities/integration-space/connectors-integrations/available-connectors/nuvei.md)).
- A second visible copy exists under `other-features/connectors/available-connectors/nuvei.md`; this PR does not edit it ([legacy copy](https://github.com/juspay/hyperswitch-docs/blob/d4f18d62f367eea87cecf0f6729efd08ca57690d/other-features/connectors/available-connectors/nuvei.md)).

## What I could not check

- I could not check this from the sandbox: the current Nuvei dashboard paths for finding credentials and registering webhook endpoints. I checked the connector source and the public Hyperswitch documentation, but those paths are not declared there.
- The matrix declares only `payments` and `disputes` webhook flows, while the exact mapper also contains refund outcomes and payout outcomes behind the payouts feature. The declaration mismatch is kept here rather than rendered as `Page gaps` content ([payment mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3634-L3675), [payout mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L3678-L3693)).
- Chargeback verification-message construction remains the source placeholder quoted above. This is retained in the rendered webhook warning because it changes the reader's setup decision.

## Decision requested

Approve the regenerated capability block, uppercase wire literals, retained source counts, source-backed webhook warning, heading normalization, and removal of the rendered review-notes section.
