### PR TITLE
docs(connectors): intro standard pass for braintree, shift4, nuvei

### DIFF
--- a/integration-space/connectors-integrations/available-connectors/braintree.md
+++ b/integration-space/connectors-integrations/available-connectors/braintree.md
@@ -8,7 +8,7 @@ metaLinks:
 
 # Braintree
 
-Braintree is a PayPal service for accepting payments in apps and websites. Merchants can accept cards with mandates, refunds, manual capture, and optional 3DS. Apple Pay, Google Pay, and PayPal are also available, with mandates supported for Apple Pay. Webhooks cover payment and refund updates.
+Braintree is a PayPal service for accepting payments in apps and websites. Merchants can accept cards with mandates, refunds, manual capture, and optional 3DS. Apple Pay, Google Pay, and PayPal are also available, with mandates supported for Apple Pay. Webhooks cover payment and refund updates, and the webhook mapper also recognizes several dispute events (see below).
 
 ### Status and capabilities
 

--- a/integration-space/connectors-integrations/available-connectors/braintree.md
+++ b/integration-space/connectors-integrations/available-connectors/braintree.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Connect Braintree to Hyperswitch and review the connector setup.
+  Accept card and wallet payments through Braintree with Hyperswitch.
 metaLinks:
   alternates:
     - braintree.md
@@ -8,7 +8,7 @@ metaLinks:
 
 # Braintree
 
-Use this guide to configure credentials and webhook behavior.
+Braintree is a PayPal service for accepting payments in apps and websites. Merchants can accept cards with mandates, refunds, manual capture, and optional 3DS. Apple Pay, Google Pay, and PayPal are also available, with mandates supported for Apple Pay. Webhooks cover payment and refund updates.
 
 ### Status and capabilities
 
@@ -53,8 +53,3 @@ The implementation recognizes 7 dispute event names ([source](https://github.com
 | `dispute_disputed` | Dispute challenged |
 
 Other event names are not supported.
-
-### Page gaps
-
-- The capability declaration lists payment and refund webhook flows, while the implemented event mapper recognizes dispute events. Confirm the intended declaration before relying on the generated webhook-flow list.
-- The connector source does not declare the dashboard paths for finding credentials or registering the webhook endpoint. Use Braintree's current dashboard guidance when completing those steps.

--- a/integration-space/connectors-integrations/available-connectors/nuvei.md
+++ b/integration-space/connectors-integrations/available-connectors/nuvei.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Connect Nuvei to Hyperswitch and review the connector setup.
+  Accept card, network token, pay later, wallet, and bank redirect payments through Nuvei with Hyperswitch.
 metaLinks:
   alternates:
     - nuvei.md
@@ -8,7 +8,7 @@ metaLinks:
 
 # Nuvei
 
-Use this guide to configure credentials and webhook behavior.
+Based in Canada, Nuvei is a fintech company. Merchants can accept cards, network tokens, Apple Pay, Google Pay, PayPal, Afterpay Clearpay, Klarna, and European bank redirects. Cards, network tokens, Apple Pay, and Google Pay support mandates, and every listed method supports refunds and manual capture. Card payments can use optional 3DS, while webhooks cover payment and dispute updates.
 
 ### Status and capabilities
 

--- a/integration-space/connectors-integrations/available-connectors/shift4.md
+++ b/integration-space/connectors-integrations/available-connectors/shift4.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Connect Shift4 to Hyperswitch and review the connector setup.
+  Accept card and bank redirect payments through Shift4 with Hyperswitch.
 metaLinks:
   alternates:
     - shift4.md
@@ -8,7 +8,7 @@ metaLinks:
 
 # Shift4
 
-Use this guide to configure credentials and webhook behavior.
+Based in the United States, Shift4 is a payment processing company. Merchants can accept Mastercard and Visa cards alongside EPS, Giropay, iDEAL, and Sofort bank redirects. Every listed method supports refunds and manual capture, while mandates are not supported. Card payments can use optional 3DS, and webhooks cover payment and refund updates.
 
 ### Status and capabilities
 


### PR DESCRIPTION
Verdict: prose-gap

## The PRs this responds to

- juspay/hyperswitch-docs#229
- juspay/hyperswitch-docs#230
- juspay/hyperswitch-docs#231

## Evidence

- Docs base: `origin/main = 7fe83914af46282d79bf9c24d28fa15da64e4417`.
- Hyperswitch source: `origin/main = 93becbaee4ee3686e1a4d5750d2e547c56c27047`.
- Each generated block records `host = http://localhost:8080`, `fetched = 2026-09-10`, and `matrix fingerprint = canonical-json-v1 sha256 27951de892af028b`.
- Braintree identity comes from [`BRAINTREE_CONNECTOR_INFO`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L1430-L1436). Its intro facts come from [`BRAINTREE_SUPPORTED_PAYMENT_METHODS`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L1341-L1428) and [`BRAINTREE_SUPPORTED_WEBHOOK_FLOWS`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L1438-L1451).
- Shift4 identity comes from [`SHIFT4_CONNECTOR_INFO`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4.rs#L1091-L1096). Its intro facts come from [`SHIFT4_SUPPORTED_PAYMENT_METHODS`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4.rs#L992-L1088) and [`SHIFT4_SUPPORTED_WEBHOOK_FLOWS`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4.rs#L1098-L1126).
- Nuvei identity comes from [`NUVEI_CONNECTOR_INFO`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L1786-L1791). Its intro facts come from [`NUVEI_SUPPORTED_PAYMENT_METHODS`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L1624-L1783) and [`NUVEI_SUPPORTED_WEBHOOK_FLOWS`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L1793-L1823).
- Step 5d required fixes to the intro stub and frontmatter description on Braintree, Shift4, and Nuvei. Block provenance, header paragraphs, authorization coverage, webhook content, one-home checks, and sibling heading style passed without edits. Exact-list checks passed: Braintree `7/7`; Shift4 `5 plus catch-all / 6`; Nuvei `51/51` dispute codes, `5/5` categories, and `5/5` DMN statuses.
- The rendered `Page gaps` section was removed from Braintree. No `Page gaps` heading was present on Shift4 or Nuvei.
- This is one PR because it applies the same edit class across three pages from one batch. The root copies under `other-features/connectors/` exist and were not edited.

Page gaps:

- Braintree declares payment and refund webhook flows in [`BRAINTREE_SUPPORTED_WEBHOOK_FLOWS`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L1438-L1451), while [`get_status()`](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L2793-L2801) recognizes dispute events. Confirm the intended declaration before relying on the generated webhook-flow list.
- The Braintree connector source does not declare dashboard paths for finding credentials or registering the webhook endpoint.

## What I could not check

- I could not check the Braintree dashboard paths from the sandbox. I checked the connector source and the existing page, but neither declares those vendor dashboard paths.

## Decision requested

Approve the shared intro standard for these pages, and decide whether the Braintree webhook-flow declaration should be corrected in the code before the next capability-block regeneration.