### PR TITLE
docs(connectors): Rapyd capability block from feature matrix

### DIFF
--- a/integration-space/connectors-integrations/available-connectors/rapyd.md
+++ b/integration-space/connectors-integrations/available-connectors/rapyd.md
@@ -1,7 +1,5 @@
 ---
-description: >-
-  Learn how to activate Rapyd as a payment connector on Juspay Hyperswitch to
-  accept and send global payments across multiple payment methods.
+description: Configure Rapyd card and wallet payments with Hyperswitch.
 metaLinks:
   alternates:
     - rapyd.md
@@ -11,49 +9,65 @@ metaLinks:
 
 <div align="left"><img src="https://hyperswitch.io/icons/homePageIcons/logos/rapydLogo.svg" alt=""></div>
 
-Rapyd connects to Hyperswitch as a `PaymentGateway` connector using `BodyKey` authentication — an Access Key and Secret Key are used to generate a per-request HMAC-SHA256 signature. The signature is computed as `HMAC-SHA256(secret_key, "{method}{url_path}{salt}{timestamp}{access_key}{secret_key}{body}")`, hex-encoded, then URL-safe Base64-encoded. Per-request `access_key`, `salt`, `timestamp`, and `signature` values are sent as individual HTTP headers on every request (no static Authorization header). All requests use `application/json`. Rapyd is a global payment network enabling businesses to accept and send payments across 100+ countries and 900+ payment methods.
+Rapyd is a payment gateway for card and wallet payments through Hyperswitch. Its connector covers Apple Pay and Google Pay alongside credit and debit cards. Refunds and delayed capture use the same integration, while mandates are not declared for these methods.
+
+### Status and capabilities
+
+<!-- generated from GET /feature_matrix; hyperswitch a17a23c4c4c907d2314043a32a9f505f7f2bd4f9; host http://localhost:8080; fetched 2026-09-10; matrix canonical-json-v1 sha256 36360b019f2761dd; 138 connectors.
+     Do not edit by hand. This block regenerates from the connector's
+     SupportedPaymentMethods declaration in code; edit that instead. -->
+
+**Integration status:** sandbox
+
+**Category:** payment gateway
+
+**Webhook flows:** disputes, payments, refunds
+
+| Payment method | Type | Mandates | Refunds | Capture methods | 3DS | Card networks | Countries | Currencies |
+|---|---|---|---|---|---|---|---|---|
+| card | Credit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Diners Club, Discover, JCB, Mastercard, UnionPay, Visa | 246 ([full list](https://hyperswitch.io/pm-list)) | 76 ([full list](https://hyperswitch.io/pm-list)) |
+| card | Debit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Diners Club, Discover, JCB, Mastercard, UnionPay, Visa | 246 ([full list](https://hyperswitch.io/pm-list)) | 76 ([full list](https://hyperswitch.io/pm-list)) |
+| wallet | Apple Pay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 59 ([full list](https://hyperswitch.io/pm-list)) | 40 ([full list](https://hyperswitch.io/pm-list)) |
+| wallet | Google Pay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 50 ([full list](https://hyperswitch.io/pm-list)) | 36 ([full list](https://hyperswitch.io/pm-list)) |
+
+To connect Rapyd to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Rapyd supports.
 
 ### Connector-Specific Notes
 
-* **Per-request HMAC signature:** Rapyd does not use a static Authorization header. Each request requires a freshly computed signature. Hyperswitch generates the `salt` (random 12-character alphanumeric), captures the `timestamp` (Unix epoch), computes the HMAC-SHA256 signature, and sends all four values — `access_key`, `salt`, `timestamp`, `signature` — as individual headers on every request.
-* **Signature construction:** `to_sign = "{http_method}{url_path}{salt}{timestamp}{access_key}{secret_key}{body}"`. The HMAC is keyed with `secret_key` using SHA-256, hex-encoded, then URL-safe Base64-encoded before sending.
-* **Credentials location:** Access Key and Secret Key are found in your Rapyd dashboard under **Developers > Access & Secret Keys**.
-* **Webhook verification:** Rapyd delivers webhook events to Hyperswitch using HMAC-SHA256 verification. Configure the Hyperswitch webhook endpoint in your Rapyd dashboard.
-* **Capture methods supported:** Automatic, Manual, and SequentialAutomatic.
-* Rapyd allows businesses to accept and send payments to any business or consumer entity anywhere in a faster, cheaper, and easier manner.
-* For a full list of supported payment methods, visit [hyperswitch.io/pm-list](https://hyperswitch.io/pm-list).
+Every API request carries a fresh signature. Hyperswitch concatenates the HTTP method, URL path, salt, timestamp, access key, secret key, and request body in that order with no delimiter. It signs that value with HMAC-SHA256 using the secret key, hex-encodes the result, then URL-safe Base64-encodes it. See [`generate_signature()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L76-L100).
 
-***
+### Authentication
 
-### Activating Rapyd via Hyperswitch
+Provide an `<access key>` and `<secret key>`. The `BodyKey` mapping assigns `api_key` to the access key and `key1` to the secret key. Rapyd does not use an `Authorization` header; each request sends `access_key`, `salt`, `timestamp`, and `signature` headers. See [`RapydAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs#L199-L217), [`get_auth_header()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L120-L126), and the [authorization request headers](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L223-L255).
 
-#### Prerequisites
+### Webhooks
 
-1. You need to be registered with Rapyd. Sign up at [rapyd.net](https://www.rapyd.net/).
-2. You should have a registered Hyperswitch account, accessible from the [Hyperswitch control center](https://app.hyperswitch.io/).
-3. Rapyd **Access Key** and **Secret Key** are found in your Rapyd dashboard under **Developers > Access & Secret Keys**.
-4. Select all payment methods you wish to use Rapyd for. Ensure these match the ones configured in your Rapyd dashboard.
+Rapyd webhook signatures use HMAC-SHA256. Hyperswitch reads the URL-safe Base64 value from the `signature` header and constructs the signed message by concatenating the webhook URL, salt, timestamp, access key, secret key, and body in that order with no delimiter. See [`get_webhook_source_verification_signature()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L746-L763) and [`get_webhook_source_verification_message()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L765-L836).
 
-[Steps to activate Rapyd on the Hyperswitch control center](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch)
+The connector maps 8 webhook event values:
 
-***
+| Wire event value | Effect |
+|---|---|
+| `PAYMENT_COMPLETED` | Payment succeeds |
+| `PAYMENT_CAPTURED` | Payment succeeds |
+| `PAYMENT_FAILED` | Payment fails |
+| `REFUND_COMPLETED` | Refund succeeds |
+| `PAYMENT_REFUND_REJECTED` | Refund fails |
+| `PAYMENT_REFUND_FAILED` | Refund fails |
+| `PAYMENT_DISPUTE_CREATED` | Dispute opens |
+| `PAYMENT_DISPUTE_UPDATED` | Dispute follows the status mapping below |
 
-### Responsibility Boundaries
+For dispute updates, 4 status values change the dispute state:
 
-**Hyperswitch owns:** routing decisions, per-request salt and timestamp generation, HMAC-SHA256 signature computation on every request, retry scheduling, and unified error mapping. **Rapyd owns:** payment execution, payment method routing, and cross-border settlement.
+| Wire status value | Effect |
+|---|---|
+| `ACT` | Dispute opens |
+| `RVW` | Dispute is challenged |
+| `LOS` | Dispute is lost |
+| `WIN` | Dispute is won |
 
-**Hyperswitch owns:** sending correctly signed requests using the Access Key and Secret Key. **Rapyd owns:** validating the signature on every request. If either credential changes in Rapyd and is not updated in Hyperswitch, all requests will fail signature validation immediately.
+The wire values come from [`RapydWebhookObjectEventType`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs#L542-L566) and [`RapydWebhookDisputeStatus`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs#L568-L590). Their effects come from [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L869-L900).
 
-***
+### Source reference
 
-### Common Failure Modes
-
-**Signature validation failure** Symptom: All requests fail with a Rapyd authentication or signature error. Fix: Verify the Access Key and Secret Key in Hyperswitch match exactly what is shown in your Rapyd dashboard under **Developers > Access & Secret Keys**. The signature is recomputed fresh on every request — any credential mismatch causes immediate failure.
-
-**Webhook verification failure** Symptom: Rapyd events arrive at Hyperswitch but payment statuses do not update. Fix: Verify the Hyperswitch webhook endpoint URL is configured correctly in your Rapyd dashboard and that the webhook secret matches.
-
-**Payment method not available** Symptom: A payment method fails with an availability error. Fix: Verify the method is enabled for your Rapyd account and matches the selection in the Hyperswitch connector configuration.
-
-***
-
-Connector implementation: `crates/hyperswitch_connectors/src/connectors/rapyd.rs`.
+The connector implementation is [`rapyd.rs`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs).

--- a/integration-space/connectors-integrations/available-connectors/rapyd.md
+++ b/integration-space/connectors-integrations/available-connectors/rapyd.md
@@ -9,7 +9,7 @@ metaLinks:
 
 <div align="left"><img src="https://hyperswitch.io/icons/homePageIcons/logos/rapydLogo.svg" alt=""></div>
 
-Rapyd is a payment gateway for card and wallet payments through Hyperswitch. Its connector covers Apple Pay and Google Pay alongside credit and debit cards. Refunds and delayed capture use the same integration, while mandates are not declared for these methods.
+Across Rapyd's payment gateway routes, card payments sit alongside Apple Pay and Google Pay. Credit and debit cards can use automatic, manual, or sequential automatic capture, while wallets use the same capture options without a 3DS step. Mandates are not supported, and refunds cover every listed method.
 
 ### Status and capabilities
 
@@ -29,6 +29,13 @@ Rapyd is a payment gateway for card and wallet payments through Hyperswitch. Its
 | card | Debit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Diners Club, Discover, JCB, Mastercard, UnionPay, Visa | 246 ([full list](https://hyperswitch.io/pm-list)) | 76 ([full list](https://hyperswitch.io/pm-list)) |
 | wallet | Apple Pay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 59 ([full list](https://hyperswitch.io/pm-list)) | 40 ([full list](https://hyperswitch.io/pm-list)) |
 | wallet | Google Pay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 50 ([full list](https://hyperswitch.io/pm-list)) | 36 ([full list](https://hyperswitch.io/pm-list)) |
+
+### Before you start
+
+1. Register with Rapyd.
+2. Sign in to the [Hyperswitch control center](https://app.hyperswitch.io/) or create your Hyperswitch account.
+3. In the Rapyd dashboard, go to **Developers > Access & Secret Keys** and copy your Access Key and Secret Key.
+4. Enable the same payment methods in Rapyd and in your Hyperswitch connector configuration.
 
 To connect Rapyd to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Rapyd supports.
 

--- a/integration-space/connectors-integrations/available-connectors/rapyd.md
+++ b/integration-space/connectors-integrations/available-connectors/rapyd.md
@@ -30,8 +30,8 @@ Across Rapyd's payment gateway routes, card payments sit alongside Apple Pay and
 | wallet | Apple Pay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 59 ([full list](https://hyperswitch.io/pm-list)) | 40 ([full list](https://hyperswitch.io/pm-list)) |
 | wallet | Google Pay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 50 ([full list](https://hyperswitch.io/pm-list)) | 36 ([full list](https://hyperswitch.io/pm-list)) |
 
-### Before you start
-
+### Activate Rapyd with Hyperswitch
+#### Before you start
 1. Register with Rapyd.
 2. Sign in to the [Hyperswitch control center](https://app.hyperswitch.io/) or create your Hyperswitch account.
 3. In the Rapyd dashboard, go to **Developers > Access & Secret Keys** and copy your Access Key and Secret Key.

--- a/integration-space/connectors-integrations/available-connectors/rapyd.md
+++ b/integration-space/connectors-integrations/available-connectors/rapyd.md
@@ -35,13 +35,14 @@ Across Rapyd's payment gateway routes, card payments sit alongside Apple Pay and
 1. Register with Rapyd.
 2. Sign in to the [Hyperswitch control center](https://app.hyperswitch.io/) or create your Hyperswitch account.
 3. In the Rapyd dashboard, go to **Developers > Access & Secret Keys** and copy your Access Key and Secret Key.
-4. Enable the same payment methods in Rapyd and in your Hyperswitch connector configuration.
+4. In the connector webhook settings in the Hyperswitch control center, put `{"access_key":"<access key>","secret_key":"<secret key>"}` in the webhook-secret setting. Use your Rapyd Access Key and Secret Key values. Hyperswitch parses this value as the Rapyd authentication object instead of reading the payment connector account credentials. See the [`RapydAuthType` fields](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs#L199-L203) and the [`RapydAuthType` webhook parse](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L778-L783).
+5. Enable the same payment methods in Rapyd and in your Hyperswitch connector configuration.
 
 To connect Rapyd to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Rapyd supports.
 
 ### Connector-Specific Notes
 
-Every API request carries a fresh signature. Hyperswitch concatenates the HTTP method, URL path, salt, timestamp, access key, secret key, and request body in that order with no delimiter. It signs that value with HMAC-SHA256 using the secret key, hex-encodes the result, then URL-safe Base64-encodes it. See [`generate_signature()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L76-L100).
+Every API request carries a fresh signature. The method component is lowercase: `post`, `get`, or `delete`, as shown by the [`post` authorization call](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L231-L235), [`delete` void call](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L344-L348), [`get` sync call](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L441-L445), [`post` capture call](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L540-L543), and [`post` refund call](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L670-L673). Hyperswitch concatenates that method, the URL path, salt, timestamp, access key, secret key, and request body in that order with no delimiter. It signs the value with HMAC-SHA256 using the secret key, hex-encodes the result, then URL-safe Base64-encodes it. See [`generate_signature()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L76-L100).
 
 ### Authentication
 
@@ -49,7 +50,7 @@ Provide an `<access key>` and `<secret key>`. The `BodyKey` mapping assigns `api
 
 ### Webhooks
 
-Rapyd webhook signatures use HMAC-SHA256. Hyperswitch reads the URL-safe Base64 value from the `signature` header and constructs the signed message by concatenating the webhook URL, salt, timestamp, access key, secret key, and body in that order with no delimiter. See [`get_webhook_source_verification_signature()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L746-L763) and [`get_webhook_source_verification_message()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L765-L836).
+The Rapyd `signature` header carries URL-safe Base64 of the hex-encoded HMAC-SHA256 output. Hyperswitch URL-safe Base64-decodes the header before the shared HMAC-SHA256 verifier compares it with the signed message. The signed message concatenates the webhook URL, salt, timestamp, access key, secret key, and body in that order with no delimiter. See the [`signature` header decode](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L752-L762), the shared [`HmacSha256` comparison](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/common_utils/src/crypto.rs#L251-L261), and [`get_webhook_source_verification_message()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L765-L836).
 
 The connector maps 8 webhook event values:
 


### PR DESCRIPTION
Verdict: content-wrong

The PRs this responds to: None. This is the requested connector backfill for Rapyd.

The evidence:
- `hyperswitch_origin_main`: `15c4865d913003f00192b9e2566ae481d44b088c`.
- `hyperswitch_docs_origin_main`: `d3178ae6ce88428ecb450018c160f837c5436af8`.
- `hyperswitch_control_center_origin_main`: `8fb87370ed647c124c92a69985a1d896171684c4`.
- `hyperswitch_sha`: `a17a23c4c4c907d2314043a32a9f505f7f2bd4f9`. Rapyd returns [`RAPYD_SUPPORTED_PAYMENT_METHODS`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L963-L1070), and the matrix route publishes those fields in [`build_connector_data()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/router/src/routes/feature_matrix.rs#L80-L109).
- `docs_sha`: `d218567033a85737ae3c36b44340414842929078`.
- `matrix_fingerprint`: `canonical-json-v1 sha256 36360b019f2761dd` from `http://localhost:8080/feature_matrix`, fetched `2026-09-10` with `138 connectors`.
- `block_verification`: `RAPYD: block matches matrix (4 rows, 3 header fields)`.
- `request_method_component`: `post`, `get`, and `delete`. The Rapyd connector builds requests at [`post` authorization](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L231-L235), [`delete` void](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L344-L348), [`get` sync](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L441-L445), [`post` capture](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L540-L543), and [`post` refund](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L670-L673).
- `auth_credentials`: `2`. [`RapydAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs#L199-L217) maps the access key and secret key. [`generate_signature()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L76-L100) gives the concatenation order and encoding. The request headers are built in [`build_request()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L223-L255).
- `webhook_signature_encoding`: Rapyd overrides `verify_webhook_source`. The connector URL-safe Base64-decodes the `signature` header, computes the HMAC-SHA256 of the signed message, hex-encodes the digest, and compares those bytes inside [`verify_webhook_source()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L799-L836). The signed message is built in [`get_webhook_source_verification_message()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L765-L797).
- `webhook_secret_format`: `{"access_key":"<access key>","secret_key":"<secret key>"}`. The exact keys come from [`RapydAuthType`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs#L199-L203). The activation guide names the field [`Source Verification Key`](https://github.com/juspay/hyperswitch-docs/blob/c27353bff58f0df5a927fdf378724121349037c4/integration-space/connectors-integrations/activate-connector-on-hyperswitch/README.md#L30-L32) and tells readers to prepare the JSON before activation and enter it in that field during activation. The webhook path parses the connector webhook details secret as that object at [`RapydAuthType webhook parse`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L778-L783), separately from payment connector account credentials.
- `webhook_events`: `8`; `dispute_statuses`: `4`; `dropped`: `0`. [`RapydWebhookObjectEventType`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs#L542-L566) applies `SCREAMING_SNAKE_CASE`. [`RapydWebhookDisputeStatus`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd/transformers.rs#L568-L590) supplies the wire status names and effects. [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/rapyd.rs#L869-L900) maps the events.
- `other_features_copy`: `other-features/connectors/available-connectors/rapyd.md` exists, is visible in repo frontmatter, and was not edited.
- `5d_checks_needing_fixes`: intro stub, frontmatter description, generated block placement, signature construction, authorization paths, webhook event names and effects, one-home cleanup, canonical headings, the three-or-more-asterisks grep, the exact-heading grep, request method casing, webhook signature encoding, and webhook secret setup. Both mechanical greps pass after the fixes.
- Deleted prose claims about capture methods, payment-method coverage, countries, and currencies. The generated Rapyd rows now own those facts.
- `setup_restore`: Restored `#### Before you start` from the page's pre-block revision, [`d2185670:rapyd.md`](https://github.com/juspay/hyperswitch-docs/blob/d218567033a85737ae3c36b44340414842929078/integration-space/connectors-integrations/available-connectors/rapyd.md#L30-L37), and rewrote it in the current register. It now keeps the registration prerequisite, Hyperswitch control center step, **Developers > Access & Secret Keys** credential path, payment-method matching step, and relative activation-guide link in one section.
- `stub_rewrite`: Replaced the cloned introduction with Rapyd-specific prose led by its card and wallet combination. It uses the block's `payment gateway` category and `automatic`, `manual`, and `sequential automatic` capture vocabulary, and says "mandates are not supported".
- `review_comments`: This requested fix-up is addressed by commits on this branch.
- `main_merge`: Merged `origin/main` into `docs/rapyd-capability` before this fix-up. The effective change remains `integration-space/connectors-integrations/available-connectors/rapyd.md`; the Files view may show commits already on main.
- `legacy_copy_comment`: The legacy-copy review comment is handled outside this PR. The seven visible legacy copies are being hidden via the GitBook dashboard as one coordinated change.
- `review_corrections`: Corrected the webhook signature evidence to the connector-owned decode-and-compare path in `verify_webhook_source()`, and updated the webhook secret setup to use the activation guide's `Source Verification Key` field name and timing.

What I could not check:
- I could not check the Rapyd signup URL from the sandbox. I tried curl against https://www.rapyd.net/; the sandbox proxy returned CONNECT tunnel 403, so the registration step remains generic.
- I could not live-check whether **Developers > Access & Secret Keys** is still the current Rapyd dashboard path. It is restored from the cited pre-block revision.
- I could not check connector-specific troubleshooting steps from code.

Page gaps: The Rapyd signup URL and current dashboard credential path could not be verified from the sandbox. Connector-specific source-backed troubleshooting is not documented.

The decision the reviewer is being asked to make: Approve the generated capability block, lowercase request-method construction, complete webhook signature encoding, Rapyd authentication object setup for webhook verification, and source-backed webhook tables for the canonical Rapyd page.