### PR TITLE
docs(connectors): dLocal capability block from feature matrix

### DIFF
--- a/integration-space/connectors-integrations/available-connectors/dlocal.md
+++ b/integration-space/connectors-integrations/available-connectors/dlocal.md
@@ -9,7 +9,7 @@ metaLinks:
 
 <div align="left"><img src="https://hyperswitch.io/icons/homePageIcons/logos/dlocalLogo.svg" alt=""></div>
 
-dLocal is a payment gateway for card and voucher payments through Hyperswitch. Its connector covers credit and debit cards alongside OXXO vouchers. Card payments support delayed capture, while the voucher path uses automatic capture. Refunds are declared for each method, and mandates are not declared.
+OXXO vouchers give dLocal's payment gateway route a cash-based option beside credit and debit cards. Cards accept automatic, manual, and sequential automatic capture, while OXXO uses automatic capture. Refunds are supported for each route, and mandates are not supported.
 
 ### Status and capabilities
 
@@ -28,6 +28,13 @@ dLocal is a payment gateway for card and voucher payments through Hyperswitch. I
 | card | Credit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Cartes Bancaires, Diners Club, Discover, Interac, JCB, Mastercard, UnionPay, Visa | - | - |
 | card | Debit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Cartes Bancaires, Diners Club, Discover, Interac, JCB, Mastercard, UnionPay, Visa | - | - |
 | voucher | OXXO | not supported | supported | automatic | not applicable | - | - | MXN |
+
+### Before you start
+
+1. Register with dLocal.
+2. Sign in to the [Hyperswitch control center](https://app.hyperswitch.io/register) or create your Hyperswitch account.
+3. Copy your Login, Secret Key, and Trans Key from the dLocal dashboard.
+4. Enable the same payment methods in dLocal and in your Hyperswitch connector configuration.
 
 To connect dLocal to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what dLocal supports.
 

--- a/integration-space/connectors-integrations/available-connectors/dlocal.md
+++ b/integration-space/connectors-integrations/available-connectors/dlocal.md
@@ -29,7 +29,9 @@ OXXO vouchers give dLocal's payment gateway route a cash-based option beside cre
 | card | Debit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Cartes Bancaires, Diners Club, Discover, Interac, JCB, Mastercard, UnionPay, Visa | - | - |
 | voucher | OXXO | not supported | supported | automatic | not applicable | - | - | MXN |
 
-### Before you start
+### Activate dLocal with Hyperswitch
+
+#### Before you start
 
 1. Register with dLocal.
 2. Sign in to the [Hyperswitch control center](https://app.hyperswitch.io/register) or create your Hyperswitch account.

--- a/integration-space/connectors-integrations/available-connectors/dlocal.md
+++ b/integration-space/connectors-integrations/available-connectors/dlocal.md
@@ -1,5 +1,5 @@
 ---
-description: Accept payments through dLocal via Hyperswitch
+description: Configure dLocal card and voucher payments with Hyperswitch.
 metaLinks:
   alternates:
     - dlocal.md
@@ -9,47 +9,40 @@ metaLinks:
 
 <div align="left"><img src="https://hyperswitch.io/icons/homePageIcons/logos/dlocalLogo.svg" alt=""></div>
 
-dLocal connects to Hyperswitch as a `PaymentGateway` connector using `SignatureKey` authentication with HMAC-SHA256 request signing. Unlike Bearer token connectors, dLocal authenticates each request by computing an HMAC-SHA256 signature of the request body using the Secret Key, then sending it alongside the Login key and Trans Key in a custom `Authorization` header. All requests use `application/json`. dLocal specializes in emerging market payments — it provides a single API to access local payment methods across Latin America, Africa, and Asia.
+dLocal is a payment gateway for card and voucher payments through Hyperswitch. Its connector covers credit and debit cards alongside OXXO vouchers. Card payments support delayed capture, while the voucher path uses automatic capture. Refunds are declared for each method, and mandates are not declared.
+
+### Status and capabilities
+
+<!-- generated from GET /feature_matrix; hyperswitch a17a23c4c4c907d2314043a32a9f505f7f2bd4f9; host http://localhost:8080; fetched 2026-09-10; matrix canonical-json-v1 sha256 36360b019f2761dd; 138 connectors.
+     Do not edit by hand. This block regenerates from the connector's
+     SupportedPaymentMethods declaration in code; edit that instead. -->
+
+**Integration status:** sandbox
+
+**Category:** payment gateway
+
+**Webhook flows:** None declared in code
+
+| Payment method | Type | Mandates | Refunds | Capture methods | 3DS | Card networks | Countries | Currencies |
+|---|---|---|---|---|---|---|---|---|
+| card | Credit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Cartes Bancaires, Diners Club, Discover, Interac, JCB, Mastercard, UnionPay, Visa | - | - |
+| card | Debit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | American Express, Cartes Bancaires, Diners Club, Discover, Interac, JCB, Mastercard, UnionPay, Visa | - | - |
+| voucher | OXXO | not supported | supported | automatic | not applicable | - | - | MXN |
+
+To connect dLocal to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what dLocal supports.
 
 ### Connector-Specific Notes
 
-* **HMAC-SHA256 request signing:** Every request carries a computed signature in the `Authorization` header, formatted as `V2-HMAC-SHA256, Signature: {hex_encoded_hmac_sha256}`. The HMAC input is `{x_login}{date}` for empty-body requests, or `{x_login}{date}{request_body}` when a body is present, signed with the Secret Key using HMAC-SHA256 and hex-encoded. The Login and Trans Key are sent as separate `X-Login` and `X-Trans-Key` headers respectively — they are not embedded in the `Authorization` value. All three credentials (Login, Secret Key, Trans Key) are required.
-* **Credentials location:** Login, Secret Key, and Trans Key are found in your dLocal dashboard.
-* **Emerging market focus:** dLocal's value is enabling local payment methods (Boleto, PIX, OXXO, local card schemes) across LatAm, Africa, and Asia through a single integration. The specific methods available depend on your dLocal account's approved countries.
-* **Capture methods supported:** Automatic, Manual, SequentialAutomatic (and Automatic for some methods).
-* **SetupMandate:** Supported for applicable payment methods.
-* For a full list of supported payment methods, visit [hyperswitch.io/pm-list](https://hyperswitch.io/pm-list).
+Each API request is signed with HMAC-SHA256. For an empty body, Hyperswitch concatenates the login and request date with no delimiter. Otherwise it concatenates the login, request date, and request body in that order with no delimiter. It hex-encodes the signature and sends `Authorization: V2-HMAC-SHA256, Signature: <hex signature>`. See [`build_headers()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/dlocal.rs#L82-L133).
 
-***
+### Authentication
 
-### Activating dLocal via Hyperswitch
+Provide a `<login>`, `<transaction key>`, and `<secret key>`. The `SignatureKey` mapping assigns `api_key` to the login, `key1` to the transaction key, and `api_secret` to the secret key. The login and transaction key are also sent separately as `X-Login: <login>` and `X-Trans-Key: <transaction key>`; the secret key is the HMAC key and is not sent as a header value. See [`DlocalAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/dlocal/transformers.rs#L225-L249) and [`build_headers()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/dlocal.rs#L82-L133).
 
-#### Prerequisites
+### Webhooks
 
-1. You need to be registered with dLocal. Sign up at [dlocal.com](https://dlocal.com/).
-2. You should have a registered Hyperswitch account, accessible from the [Hyperswitch control center](https://app.hyperswitch.io/register).
-3. dLocal API keys — **Login**, **Secret Key**, and **Trans Key** — are found in your dLocal dashboard.
+Webhooks are not currently supported. Payment status updates rely on syncing with the API. The webhook implementation returns `EventNotSupported` and does not provide a resource object. See [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/dlocal.rs#L692-L715).
 
-[Steps to activate dLocal on the Hyperswitch control center](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch)
+### Source reference
 
-***
-
-### Responsibility Boundaries
-
-**Hyperswitch owns:** routing decisions, retry scheduling, mandate record storage, HMAC signature construction on each request, and unified error mapping. **dLocal owns:** payment execution, local payment method routing in each market, and country-level compliance. dLocal determines which local payment methods are available based on your merchant account's approved markets — Hyperswitch cannot enable a local method that dLocal has not approved for your account.
-
-**Hyperswitch owns:** computing and sending the HMAC-SHA256 signature on every request. **dLocal owns:** validating that signature. If the Secret Key changes in dLocal and is not updated in Hyperswitch, all requests will fail authentication.
-
-***
-
-### Common Failure Modes
-
-**HMAC signature mismatch** Symptom: All requests fail with a dLocal authentication error. Fix: Verify that all three credentials (Login, Secret Key, Trans Key) in Hyperswitch match the ones in your dLocal dashboard exactly. Any mismatch causes the computed signature to fail dLocal's validation.
-
-**Local payment method unavailable** Symptom: A specific local payment method (e.g. Boleto, PIX) fails with an availability error. Fix: Confirm with dLocal that the specific method and country combination is approved for your merchant account.
-
-**Currency not supported for target market** Symptom: A payment fails with a currency or market error. Fix: dLocal processes payments in local currencies for each market. Verify the currency-country combination is supported by your dLocal account configuration.
-
-***
-
-Connector implementation: `crates/hyperswitch_connectors/src/connectors/dlocal.rs`.
+The connector implementation is [`dlocal.rs`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/dlocal.rs).


### PR DESCRIPTION
Verdict: content-wrong

The PRs this responds to: None. This is the requested connector backfill for dLocal.

The evidence:
- `hyperswitch_sha`: `a17a23c4c4c907d2314043a32a9f505f7f2bd4f9`. dLocal returns [`DLOCAL_SUPPORTED_PAYMENT_METHODS`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/dlocal.rs#L719-L820), and the matrix route publishes those fields in [`build_connector_data()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/router/src/routes/feature_matrix.rs#L80-L109).
- `docs_sha`: `d218567033a85737ae3c36b44340414842929078`.
- `matrix_fingerprint`: `canonical-json-v1 sha256 36360b019f2761dd` from `http://localhost:8080/feature_matrix`, fetched `2026-09-10` with `138 connectors`.
- `block_verification`: `DLOCAL: block matches matrix (3 rows, 3 header fields)`.
- `auth_credentials`: `3`; `signature_input_forms`: `2`; `dropped`: `0`. [`DlocalAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/dlocal/transformers.rs#L225-L249) maps the login, transaction key, and secret key. [`build_headers()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/dlocal.rs#L82-L133) defines both input orders, the no-delimiter construction, HMAC-SHA256, hex encoding, and the request headers.
- `webhook_events`: `0`; `dropped`: `0`. [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/dlocal.rs#L692-L715) returns `EventNotSupported`, and resource extraction returns `WebhooksNotImplemented`.
- `other_features_copy`: `other-features/connectors/available-connectors/dlocal.md` exists, has `hidden: true` in repo frontmatter, and was not edited.
- `5d_checks_needing_fixes`: intro stub, frontmatter description, generated block placement, credential names, both signature constructions, authorization header placeholders, webhook statement, one-home cleanup, canonical headings, the three-or-more-asterisks grep, and the exact-heading grep. Both mechanical greps pass after the fixes.
- Deleted prose claims about methods, capture, mandates, countries, and currencies. The generated dLocal rows now own those facts.
- `setup_restore`: Restored `### Before you start` from the page's pre-block revision, [`d2185670:dlocal.md`](https://github.com/juspay/hyperswitch-docs/blob/d218567033a85737ae3c36b44340414842929078/integration-space/connectors-integrations/available-connectors/dlocal.md#L27-L33), and rewrote it in the current register. It now keeps the registration prerequisite, Hyperswitch control center step, generic vendor-dashboard credential step, payment-method matching step, and relative activation-guide link in one section.
- `stub_rewrite`: Replaced the cloned introduction with dLocal-specific prose led by its OXXO voucher row beside cards. It uses the block's `payment gateway` category and separates card `automatic`, `manual`, and `sequential automatic` capture from OXXO `automatic` capture. It says "mandates are not supported".
- `review_comments`: Open review comments are addressed by commits on this branch. No PR comments were posted.

What I could not check:
- I could not check the dLocal signup URL from the sandbox. I tried curl against https://dlocal.com/; the sandbox proxy returned CONNECT tunnel 403, so the registration step remains generic.
- I could not check a more specific dLocal dashboard credential path from the sandbox. The pre-block revision names only the dLocal dashboard, so the restored step remains generic.
- I could not check connector-specific troubleshooting steps from code.

Page gaps: The dLocal signup URL and a specific dashboard credential path could not be verified from the sandbox. Connector-specific source-backed troubleshooting is not documented.

The decision the reviewer is being asked to make: Approve the generated capability block and the source-backed dLocal signature and webhook prose for the canonical connector page.