### PR TITLE
docs(connectors): GoCardless capability block from feature matrix

### DIFF
--- a/integration-space/connectors-integrations/available-connectors/gocardless.md
+++ b/integration-space/connectors-integrations/available-connectors/gocardless.md
@@ -27,7 +27,9 @@ ACH, BECS, and SEPA Direct Debit define the GoCardless payment gateway route. Ma
 | bank debit | BECS Direct Debit | supported | supported | automatic, sequential automatic | AUS | AUD |
 | bank debit | SEPA Direct Debit | supported | supported | automatic, sequential automatic | 30 ([full list](https://hyperswitch.io/pm-list)) | 7 ([full list](https://hyperswitch.io/pm-list)) |
 
-### Before you start
+### Activate GoCardless with Hyperswitch
+
+#### Before you start
 
 1. Create a GoCardless sandbox account.
 2. Sign in to the [Hyperswitch control center](https://app.hyperswitch.io/) or create your Hyperswitch account.

--- a/integration-space/connectors-integrations/available-connectors/gocardless.md
+++ b/integration-space/connectors-integrations/available-connectors/gocardless.md
@@ -1,7 +1,5 @@
 ---
-description: >-
-  Accept bank payments, Direct Debit, and Open Banking via GoCardless through
-  Juspay Hyperswitch.
+description: Configure GoCardless bank debit payments with Hyperswitch.
 metaLinks:
   alternates:
     - gocardless.md
@@ -9,52 +7,77 @@ metaLinks:
 
 # GoCardless
 
-GoCardless connects to Hyperswitch as a `PaymentGateway` connector using `HeaderKey` authentication — the Access Token is sent as `Authorization: Bearer {access_token}` on every request. All requests also include a `GoCardless-Version: 2015-07-06` header that pins the API version. All requests use `application/json`. GoCardless specialises in bank-pull payments: Direct Debit, recurring bank debits, and Open Banking.
+GoCardless is a payment gateway for bank debit payments through Hyperswitch. Its connector covers ACH, SEPA, and BECS Direct Debit. Each declared method supports mandates and refunds. Automatic and sequential automatic capture are available across the declared methods.
+
+### Status and capabilities
+
+<!-- generated from GET /feature_matrix; hyperswitch a17a23c4c4c907d2314043a32a9f505f7f2bd4f9; host http://localhost:8080; fetched 2026-09-10; matrix canonical-json-v1 sha256 36360b019f2761dd; 138 connectors.
+     Do not edit by hand. This block regenerates from the connector's
+     SupportedPaymentMethods declaration in code; edit that instead. -->
+
+**Integration status:** sandbox
+
+**Category:** payment gateway
+
+**Webhook flows:** mandates, payments, refunds
+
+| Payment method | Type | Mandates | Refunds | Capture methods | Countries | Currencies |
+|---|---|---|---|---|---|---|
+| bank debit | ACH Direct Debit | supported | supported | automatic, sequential automatic | USA | USD |
+| bank debit | BECS Direct Debit | supported | supported | automatic, sequential automatic | AUS | AUD |
+| bank debit | SEPA Direct Debit | supported | supported | automatic, sequential automatic | 30 ([full list](https://hyperswitch.io/pm-list)) | 7 ([full list](https://hyperswitch.io/pm-list)) |
+
+To connect GoCardless to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what GoCardless supports.
 
 ### Connector-Specific Notes
 
-- **Bearer token auth with version header:** GoCardless uses a static Access Token (not a rotating OAuth token) as the Bearer credential. Every request also sends `GoCardless-Version: 2015-07-06` to pin the API version. This version is fixed in the Hyperswitch implementation.
-- **Credentials location:** Access Token is found in your GoCardless dashboard under **Developers → Create → Access Token**.
-- **Webhook verification:** GoCardless signs webhook events with HMAC-SHA256. Configure the Hyperswitch webhook endpoint in your GoCardless dashboard and store the webhook signing secret.
-- **Capture methods supported:** Automatic, SequentialAutomatic. Manual capture is not supported.
-- **SetupMandate:** Supported for applicable payment methods (Direct Debit mandates).
-- GoCardless specialises in bank payments (Direct Debit, ACH, SEPA, BACS) and recurring payment collection. It is widely used in Europe, US, and ANZ for subscription billing and invoice collection.
-- For a full list of supported payment methods, visit [hyperswitch.io/pm-list](https://hyperswitch.io/pm-list).
+Hyperswitch sends `GoCardless-Version: 2015-07-06` on connector requests. This pins the API version used by the implementation. See [`GOCARDLESS_VERSION`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L85-L110).
 
----
+### Authentication
 
-### Activating GoCardless via Hyperswitch
+Provide an `<access token>`. The `HeaderKey` mapping assigns `api_key` to the access token, and every connector request sends `Authorization: Bearer <access token>`. See [`GocardlessAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless/transformers.rs#L635-L649) and [`get_auth_header()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L131-L142).
 
-#### Prerequisites
+### Webhooks
 
-1. You need to be registered with GoCardless. Sign up at [manage-sandbox.gocardless.com](https://manage-sandbox.gocardless.com/sign-up).
-2. You should have a registered Hyperswitch account, accessible from the [Hyperswitch control center](https://app.hyperswitch.io/).
-3. GoCardless **Access Token** is found in your GoCardless dashboard under **Developers → Create → Access Token**.
-4. Select all payment methods you wish to use GoCardless for. Ensure these match the ones configured in your GoCardless dashboard.
+Configure a `<webhook signing secret>` for source verification. Hyperswitch reads a hex-encoded signature from `Webhook-Signature` and verifies HMAC-SHA256 over the raw request body using the configured `merchant_secret`. See [`get_webhook_source_verification_signature()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L719-L753) and [`verify_webhook_source()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_interfaces/src/webhooks.rs#L265-L301).
 
-[Steps to activate GoCardless on the Hyperswitch control center](https://docs.hyperswitch.io/hyperswitch-cloud/connectors/activate-connector-on-hyperswitch)
+The connector maps 30 webhook action values:
 
----
+| Resource | Wire action value | Effect |
+|---|---|---|
+| Payments | `created` | Payment is processing |
+| Payments | `customer_approval_granted` | Payment is processing |
+| Payments | `customer_approval_denied` | Payment fails |
+| Payments | `submitted` | Payment is processing |
+| Payments | `confirmed` | Payment succeeds |
+| Payments | `paid_out` | Payment succeeds |
+| Payments | `late_failure_settled` | Payment fails |
+| Payments | `surcharge_fee_debited` | No status update |
+| Payments | `failed` | Payment fails |
+| Payments | `cancelled` | Payment fails |
+| Payments | `resubmission_required` | No status update |
+| Refunds | `created` | No status update |
+| Refunds | `failed` | Refund fails |
+| Refunds | `paid` | Refund succeeds |
+| Refunds | `refund_settled` | No status update |
+| Refunds | `funds_returned` | No status update |
+| Mandates | `created` | No status update |
+| Mandates | `customer_approval_granted` | No status update |
+| Mandates | `customer_approval_skipped` | No status update |
+| Mandates | `active` | Mandate becomes active |
+| Mandates | `cancelled` | Mandate is revoked |
+| Mandates | `failed` | Mandate is revoked |
+| Mandates | `transferred` | No status update |
+| Mandates | `expired` | Mandate is revoked |
+| Mandates | `submitted` | No status update |
+| Mandates | `resubmission_requested` | No status update |
+| Mandates | `reinstated` | Mandate becomes active |
+| Mandates | `replaced` | No status update |
+| Mandates | `consumed` | Mandate is revoked |
+| Mandates | `blocked` | No status update |
 
-### Responsibility Boundaries
+The wire values use `snake_case` in [`PaymentsAction`, `RefundsAction`, and `MandatesAction`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless/transformers.rs#L839-L905). Their effects come from [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L790-L849).
 
-**Hyperswitch owns:** routing decisions, retry scheduling, Direct Debit mandate reference storage, sending the Access Token as the Bearer credential and pinning the API version on every request, and unified error mapping. **GoCardless owns:** payment execution, bank debit collection, mandate management, and webhook delivery.
+### Source reference
 
-**Hyperswitch owns:** presenting the correct Access Token on every request. **GoCardless owns:** validating it. If the Access Token is revoked in GoCardless and not replaced in Hyperswitch, all requests will fail authentication immediately.
-
----
-
-### Common Failure Modes
-
-**Authentication failure**
-Symptom: All requests fail with a GoCardless 401 or authentication error. Fix: Verify the Access Token in Hyperswitch matches the one generated in your GoCardless dashboard under **Developers → Access Tokens**. If the token was revoked or rotated, generate a new one and update Hyperswitch.
-
-**Mandate setup failure**
-Symptom: Direct Debit mandate setup fails or mandate reference is rejected on subsequent charges. Fix: Verify the payment method type and customer bank details are correctly provided in the SetupMandate request. GoCardless mandates require valid bank account details specific to each payment scheme (BACS, SEPA, ACH).
-
-**Webhook verification failure**
-Symptom: GoCardless webhooks arrive at Hyperswitch but events are not processed. Fix: Verify the webhook signing secret stored in Hyperswitch matches the one GoCardless uses to sign events. Mismatched secrets cause HMAC-SHA256 verification to fail.
-
----
-
-Connector implementation: `crates/hyperswitch_connectors/src/connectors/gocardless.rs`.
+The connector implementation is [`gocardless.rs`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs).

--- a/integration-space/connectors-integrations/available-connectors/gocardless.md
+++ b/integration-space/connectors-integrations/available-connectors/gocardless.md
@@ -7,7 +7,7 @@ metaLinks:
 
 # GoCardless
 
-GoCardless is a payment gateway for bank debit payments through Hyperswitch. Its connector covers ACH, SEPA, and BECS Direct Debit. Each declared method supports mandates and refunds. Automatic and sequential automatic capture are available across the declared methods.
+ACH, BECS, and SEPA Direct Debit define the GoCardless payment gateway route. Mandates and refunds apply to every bank debit method. Capture stays automatic or sequential automatic throughout.
 
 ### Status and capabilities
 
@@ -26,6 +26,13 @@ GoCardless is a payment gateway for bank debit payments through Hyperswitch. Its
 | bank debit | ACH Direct Debit | supported | supported | automatic, sequential automatic | USA | USD |
 | bank debit | BECS Direct Debit | supported | supported | automatic, sequential automatic | AUS | AUD |
 | bank debit | SEPA Direct Debit | supported | supported | automatic, sequential automatic | 30 ([full list](https://hyperswitch.io/pm-list)) | 7 ([full list](https://hyperswitch.io/pm-list)) |
+
+### Before you start
+
+1. Create a GoCardless sandbox account.
+2. Sign in to the [Hyperswitch control center](https://app.hyperswitch.io/) or create your Hyperswitch account.
+3. In the GoCardless dashboard, go to **Developers > Create > Access Token** and create or copy your Access Token.
+4. Enable the same payment methods in GoCardless and in your Hyperswitch connector configuration.
 
 To connect GoCardless to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what GoCardless supports.
 

--- a/integration-space/connectors-integrations/available-connectors/gocardless.md
+++ b/integration-space/connectors-integrations/available-connectors/gocardless.md
@@ -48,42 +48,42 @@ Provide an `<access token>`. The `HeaderKey` mapping assigns `api_key` to the ac
 
 Configure a `<webhook signing secret>` for source verification. Hyperswitch reads a hex-encoded signature from `Webhook-Signature` and verifies HMAC-SHA256 over the raw request body using the configured `merchant_secret`. See [`get_webhook_source_verification_signature()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L719-L753) and [`verify_webhook_source()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_interfaces/src/webhooks.rs#L265-L301).
 
-The connector maps 30 webhook action values:
+The connector processes 11 payment action values:
+
+| Wire action value | Effect |
+|---|---|
+| `created` | Payment is processing |
+| `customer_approval_granted` | Payment is processing |
+| `customer_approval_denied` | Payment fails |
+| `submitted` | Payment is processing |
+| `confirmed` | Payment succeeds |
+| `paid_out` | Payment succeeds |
+| `late_failure_settled` | Payment fails |
+| `surcharge_fee_debited` | No status update |
+| `failed` | Payment fails |
+| `cancelled` | Payment fails |
+| `resubmission_required` | No status update |
+
+Because [`WebhookAction`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless/transformers.rs#L855-L860) is untagged and tries payment actions first, refund webhooks with actions `created` or `failed`, and mandate webhooks with actions `cancelled`, `created`, `customer_approval_granted`, `failed`, or `submitted`, are processed as payment events regardless of `resource_type`.
+
+The remaining 3 refund actions and 9 mandate actions reach their resource-specific effects:
 
 | Resource | Wire action value | Effect |
 |---|---|---|
-| Payments | `created` | Payment is processing |
-| Payments | `customer_approval_granted` | Payment is processing |
-| Payments | `customer_approval_denied` | Payment fails |
-| Payments | `submitted` | Payment is processing |
-| Payments | `confirmed` | Payment succeeds |
-| Payments | `paid_out` | Payment succeeds |
-| Payments | `late_failure_settled` | Payment fails |
-| Payments | `surcharge_fee_debited` | No status update |
-| Payments | `failed` | Payment fails |
-| Payments | `cancelled` | Payment fails |
-| Payments | `resubmission_required` | No status update |
-| Refunds | `created` | No status update |
-| Refunds | `failed` | Refund fails |
 | Refunds | `paid` | Refund succeeds |
 | Refunds | `refund_settled` | No status update |
 | Refunds | `funds_returned` | No status update |
-| Mandates | `created` | No status update |
-| Mandates | `customer_approval_granted` | No status update |
 | Mandates | `customer_approval_skipped` | No status update |
 | Mandates | `active` | Mandate becomes active |
-| Mandates | `cancelled` | Mandate is revoked |
-| Mandates | `failed` | Mandate is revoked |
 | Mandates | `transferred` | No status update |
 | Mandates | `expired` | Mandate is revoked |
-| Mandates | `submitted` | No status update |
 | Mandates | `resubmission_requested` | No status update |
 | Mandates | `reinstated` | Mandate becomes active |
 | Mandates | `replaced` | No status update |
 | Mandates | `consumed` | Mandate is revoked |
 | Mandates | `blocked` | No status update |
 
-The wire values use `snake_case` in [`PaymentsAction`, `RefundsAction`, and `MandatesAction`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless/transformers.rs#L839-L905). Their effects come from [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L790-L849).
+The wire values use `snake_case` in [`PaymentsAction`, `RefundsAction`, and `MandatesAction`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless/transformers.rs#L855-L905). Their effects come from [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L790-L849).
 
 ### Source reference
 


### PR DESCRIPTION
Verdict: content-wrong

The PRs this responds to: None. This is the requested connector backfill for GoCardless.

The evidence:
- `hyperswitch_sha`: `a17a23c4c4c907d2314043a32a9f505f7f2bd4f9`. GoCardless returns [`GOCARDLESS_SUPPORTED_PAYMENT_METHODS`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L876-L946), and the matrix route publishes those fields in [`build_connector_data()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/router/src/routes/feature_matrix.rs#L80-L109).
- `hyperswitch_origin_main`: `740e642eabb5b54094f589d4ebc08aa9e796fab1`, fetched `2026-09-11`.
- `docs_origin_main`: `d218567033a85737ae3c36b44340414842929078`, fetched `2026-09-11`.
- `matrix_fingerprint`: `canonical-json-v1 sha256 36360b019f2761dd` from `http://localhost:8080/feature_matrix`, fetched `2026-09-10` with `138 connectors`.
- `block_verification`: `GOCARDLESS: block matches matrix (3 rows, 3 header fields)`.
- `auth_credentials`: `1`; `dropped`: `0`. [`GocardlessAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless/transformers.rs#L635-L649) maps the access token, and [`get_auth_header()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L131-L142) builds the Bearer header.
- `webhook_action_enum_counts`: `payments=11 refunds=5 mandates=14 dropped=0`. See [`PaymentsAction`, `RefundsAction`, and `MandatesAction`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless/transformers.rs#L862-L905).
- `runtime_dispatch`: The untagged [`WebhookAction`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless/transformers.rs#L855-L860) dispatch means payment parsing captures refund `created`/`failed` and mandate `cancelled`/`created`/`customer_approval_granted`/`failed`/`submitted`.
- `reachable_resource_actions`: `refunds=3 mandates=9 effects=12 dropped=0`, covering refund `paid`/`refund_settled`/`funds_returned` and mandate `customer_approval_skipped`/`active`/`transferred`/`expired`/`resubmission_requested`/`reinstated`/`replaced`/`consumed`/`blocked`. See [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L790-L849).
- `webhook_verification`: HMAC-SHA256 over the raw body with a hex signature from `Webhook-Signature`, as declared by [the connector verification methods](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/gocardless.rs#L719-L753). The shared [`verify_webhook_source()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_interfaces/src/webhooks.rs#L265-L301) feeds `connector_webhook_secrets.secret` to the algorithm.
- `upstream_report`: The parsing overlap is reported upstream; this page documents the current runtime behavior pending the upstream fix.
- `other_features_copy`: `other-features/connectors/available-connectors/gocardless.md` exists, has `hidden: true` in repo frontmatter, and was not edited.
- `5d_checks_needing_fixes`: intro stub, frontmatter description, generated block placement, API-version note, authentication placeholders, webhook verification key, complete wire-event table, effect column, one-home cleanup, canonical headings, the three-or-more-asterisks grep, and the exact-heading grep. Both mechanical greps pass after the fixes.
- Deleted prose claims about methods, capture, mandates, countries, and currencies. The generated GoCardless rows now own those facts.
- `setup_restore`: Restored `### Before you start` from the page's pre-block revision, [`d2185670:gocardless.md`](https://github.com/juspay/hyperswitch-docs/blob/d218567033a85737ae3c36b44340414842929078/integration-space/connectors-integrations/available-connectors/gocardless.md#L28-L35), and rewrote it in the current register. It now keeps the sandbox-registration prerequisite, Hyperswitch control center step, **Developers > Create > Access Token** credential path, payment-method matching step, and relative activation-guide link in one section.
- `stub_rewrite`: Replaced the cloned introduction with GoCardless-specific prose led by its ACH, BECS, and SEPA Direct Debit rows. It uses the block's `payment gateway` category and `automatic` and `sequential automatic` capture vocabulary while preserving mandate support.
- `review_comments`: Open review comments are addressed by commits on this branch. No PR comments were posted.

What I could not check:
- I could not check the GoCardless signup URL from the sandbox. I tried curl against https://manage-sandbox.gocardless.com/sign-up; the sandbox proxy returned CONNECT tunnel 403, so the registration step remains generic.
- I could not live-check whether **Developers > Create > Access Token** is still the current GoCardless dashboard path. It is restored from the cited pre-block revision.
- I could not check connector-specific troubleshooting steps from code.
- No upstream issue URL or number was supplied, so the upstream report could not be linked or verified.

Page gaps: The GoCardless signup URL and current dashboard credential path could not be verified from the sandbox. Connector-specific source-backed troubleshooting is not documented.

The decision the reviewer is being asked to make: Approve the runtime-dispatch webhook tables, with current behavior documented while the upstream issue is pending, and the generated capability block for the canonical GoCardless page.