### PR TITLE
docs(connectors): restore setup sections

### DIFF
--- a/integration-space/connectors-integrations/available-connectors/aci.md
+++ b/integration-space/connectors-integrations/available-connectors/aci.md
@@ -57,24 +57,20 @@ ACI does not currently declare webhook flows in `SupportedPaymentMethods`, so th
 
 The connector source includes incoming-webhook handling code, but until webhook flows are declared for ACI, those implementation details are not documented here as a supported integration feature.
 
-### Activate ACI with Hyperswitch
+### Before you start
 
-#### Before you start
-
-1. You need to be registered with ACI. Sign up at [aciworldwide.com](https://www.aciworldwide.com/).
-2. You should have a registered Hyperswitch account, accessible from the [Hyperswitch control center](https://app.hyperswitch.io/).
-3. Have the credentials listed in [Authentication](#authentication) ready.
+1. Register with ACI.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. Find the API Key and Entity ID in your ACI dashboard.
+4. Have the credentials listed in [Authentication](#authentication) ready.
 
 To connect ACI to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what ACI supports.
-
-***
 
 ### Troubleshooting
 
 **Webhook expectations**
 Symptom: You expect webhook-driven payment or refund status updates for ACI. Fix: use the declared capabilities in the status block above as the supported behavior for this connector.
 
-***
 
 ### Source reference
 

--- a/integration-space/connectors-integrations/available-connectors/authorizedotnet.md
+++ b/integration-space/connectors-integrations/available-connectors/authorizedotnet.md
@@ -51,17 +51,15 @@ The connector recognizes six webhook event names:
 
 The event names and mappings are defined by [`AuthorizedotnetIncomingWebhookEventType`](https://github.com/juspay/hyperswitch/blob/2ef1f9ee5bdf65356c3169f4f5db67fa1d4de7bc/crates/hyperswitch_connectors/src/connectors/authorizedotnet/transformers.rs#L2340-L2368).
 
-### Activate Authorize.net with Hyperswitch
+### Before you start
 
-#### Before you start
-
-1. You need to be registered with Authorize.net. Sign up at [authorize.net](https://www.authorize.net/).
-2. You should have a registered Hyperswitch account, accessible from the [Hyperswitch control center](https://hyperswitch.io/contact-sales).
-3. Have the credentials listed in [Authentication](#authentication) ready.
+1. Register with Authorize.net.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. In the Authorize.net dashboard, go to **Account → Security Settings** to find the API Login ID and Transaction Key.
+4. Under **Account → Digital Payment Solutions**, enable the payment methods you plan to select in Hyperswitch.
+5. Have the credentials listed in [Authentication](#authentication) ready.
 
 To connect Authorize.net to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Authorize.net supports.
-
----
 
 ### Source reference
 

--- a/integration-space/connectors-integrations/available-connectors/braintree.md
+++ b/integration-space/connectors-integrations/available-connectors/braintree.md
@@ -38,7 +38,7 @@ Supply the Public Key and Private Key in the connector configuration. Hyperswitc
 
 1. Register with Braintree.
 2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
-3. In the Braintree dashboard, go to **Home → Settings → API** to find the Merchant ID, Public Key, and Private Key.
+3. In the Braintree dashboard, go to **Home → Settings → API** to find the Public Key and Private Key.
 4. Under **Home → Settings → API → Webhooks**, register the Hyperswitch webhook endpoint.
 5. Have the credentials listed in [Authentication](#authentication) ready.
 

--- a/integration-space/connectors-integrations/available-connectors/braintree.md
+++ b/integration-space/connectors-integrations/available-connectors/braintree.md
@@ -30,11 +30,19 @@ Braintree is a PayPal service for accepting payments in apps and websites. Merch
 | wallet | Google Pay | not supported | supported | automatic, manual, sequential automatic | not applicable | - | - | - |
 | wallet | PayPal | not supported | supported | automatic, manual, sequential automatic | not applicable | - | - | - |
 
-### Configure Braintree
+### Authentication
 
-Enter the Braintree public key in the API key field and the private key in the API secret field. Hyperswitch uses the public key as the HTTP Basic username and the private key as the HTTP Basic password. The shared third credential field is not used for Braintree authentication ([credential mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L215-L237), [request header](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/braintree.rs#L136-L149)).
+Supply the Public Key and Private Key in the connector configuration. Hyperswitch uses the Public Key as the HTTP Basic username and the Private Key as the password, then Base64-encodes `public_key:private_key`. The shared third credential field is not used for Braintree authentication. See [`BraintreeAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L215-L237) and [`get_auth_header()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/braintree.rs#L136-L149).
 
-Follow the [connector activation guide](../activate-connector-on-hyperswitch/README.md) to add these credentials in Hyperswitch. Use Braintree's current dashboard guidance to find the credentials and register the webhook endpoint.
+### Before you start
+
+1. Register with Braintree.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. In the Braintree dashboard, go to **Home → Settings → API** to find the Merchant ID, Public Key, and Private Key.
+4. Under **Home → Settings → API → Webhooks**, register the Hyperswitch webhook endpoint.
+5. Have the credentials listed in [Authentication](#authentication) ready.
+
+To connect Braintree to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Braintree supports.
 
 ### Webhooks
 

--- a/integration-space/connectors-integrations/available-connectors/fiserv.md
+++ b/integration-space/connectors-integrations/available-connectors/fiserv.md
@@ -40,17 +40,15 @@ Supply an API Key, API Secret, and Merchant ID in the connector configuration. H
 
 Fiserv webhooks are not currently processed by this connector. Do not configure Fiserv webhooks as the source of status updates in Hyperswitch. The incoming webhook implementation returns `EventNotSupported` and `WebhooksNotImplemented`; see [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/2ef1f9ee5bdf65356c3169f4f5db67fa1d4de7bc/crates/hyperswitch_connectors/src/connectors/fiserv.rs#L910-L934).
 
-### Activate Fiserv with Hyperswitch
+### Before you start
 
-#### Before you start
-
-1. You need to be registered with Fiserv. Sign up at [fiserv.com](https://www.fiserv.com/).
-2. You should have a registered Hyperswitch account, accessible from the [Hyperswitch control center](https://app.hyperswitch.io/).
-3. Have the credentials listed in [Authentication](#authentication) ready.
+1. Register with Fiserv.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. In the Fiserv dashboard, open **Credentials** to find the API Key, API Secret, Merchant ID, and Terminal ID.
+4. Enable the same payment methods in Fiserv that you plan to select in Hyperswitch.
+5. Have the credentials listed in [Authentication](#authentication) ready.
 
 To connect Fiserv to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Fiserv supports.
-
-***
 
 ### Source reference
 

--- a/integration-space/connectors-integrations/available-connectors/fiserv.md
+++ b/integration-space/connectors-integrations/available-connectors/fiserv.md
@@ -44,7 +44,7 @@ Fiserv webhooks are not currently processed by this connector. Do not configure 
 
 1. Register with Fiserv.
 2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
-3. In the Fiserv dashboard, open **Credentials** to find the API Key, API Secret, Merchant ID, and Terminal ID.
+3. In the Fiserv dashboard, open **Credentials** to find the API Key, API Secret, and Merchant ID.
 4. Enable the same payment methods in Fiserv that you plan to select in Hyperswitch.
 5. Have the credentials listed in [Authentication](#authentication) ready.
 

--- a/integration-space/connectors-integrations/available-connectors/klarna.md
+++ b/integration-space/connectors-integrations/available-connectors/klarna.md
@@ -35,13 +35,13 @@ Supply an API Username and API Password in the connector configuration. Hyperswi
 
 Klarna webhooks are not currently processed by this connector. Do not configure Klarna webhooks as the source of status updates in Hyperswitch. The incoming webhook implementation returns `EventNotSupported` and `WebhooksNotImplemented`; see [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/klarna.rs#L1450-L1474).
 
-### Activate Klarna with Hyperswitch
-
-#### Before you start
+### Before you start
 
 1. Register with Klarna.
-2. Create a Hyperswitch account.
-3. Have the credentials listed in [Authentication](#authentication) ready.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. In the Klarna merchant portal, go to **Settings → API credentials** to find the API Username and API Password.
+4. Enable the same payment methods in Klarna that you plan to select in Hyperswitch.
+5. Have the credentials listed in [Authentication](#authentication) ready.
 
 To connect Klarna to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Klarna supports.
 

--- a/integration-space/connectors-integrations/available-connectors/nuvei.md
+++ b/integration-space/connectors-integrations/available-connectors/nuvei.md
@@ -37,11 +37,19 @@ Based in Canada, Nuvei is a fintech company. Merchants can accept cards, network
 | wallet | Google Pay | supported | supported | automatic, manual, sequential automatic | not applicable | - | 237 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
 | wallet | PayPal | not supported | supported | automatic, manual, sequential automatic | not applicable | - | 10 ([full list](https://hyperswitch.io/pm-list)) | 90 ([full list](https://hyperswitch.io/pm-list)) |
 
-### Configure Nuvei
+### Authentication
 
-Enter the merchant ID in the API key field, the merchant site ID in the `key1` field, and the merchant secret in the API secret field. Nuvei requests do not use an Authorization header. The connector places the authentication values and request checksum in the request body ([credential mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L1734-L1757), [empty auth header](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L127-L133)).
+Supply the Merchant ID in the API key field, the Merchant Site ID in the `key1` field, and the Merchant Secret in the API secret field. Nuvei requests do not use an Authorization header; the connector places these authentication values and the request checksum in the request body. See [`NuveiAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L1734-L1757) and [`get_auth_header()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L127-L133).
 
-Follow the [connector activation guide](../activate-connector-on-hyperswitch/README.md) to add these credentials in Hyperswitch. Use Nuvei's current dashboard guidance to find the credentials and register webhook endpoints.
+### Before you start
+
+1. Register with Nuvei.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. In the Nuvei dashboard, go to **Settings → My Account → Account Details** to find the API key.
+4. Enable the same payment methods in Nuvei that you plan to select in Hyperswitch.
+5. Have the credentials listed in [Authentication](#authentication) ready.
+
+To connect Nuvei to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Nuvei supports.
 
 ### Webhooks
 

--- a/integration-space/connectors-integrations/available-connectors/nuvei.md
+++ b/integration-space/connectors-integrations/available-connectors/nuvei.md
@@ -45,7 +45,7 @@ Supply the Merchant ID in the API key field, the Merchant Site ID in the `key1` 
 
 1. Register with Nuvei.
 2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
-3. In the Nuvei dashboard, go to **Settings → My Account → Account Details** to find the API key.
+3. In the Nuvei dashboard, go to **Settings → My Account → Account Details** to find the Merchant ID, Merchant Site ID, and Merchant Secret.
 4. Enable the same payment methods in Nuvei that you plan to select in Hyperswitch.
 5. Have the credentials listed in [Authentication](#authentication) ready.
 

--- a/integration-space/connectors-integrations/available-connectors/shift4.md
+++ b/integration-space/connectors-integrations/available-connectors/shift4.md
@@ -31,11 +31,19 @@ Based in the United States, Shift4 is a payment processing company. Merchants ca
 | card | Credit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | Mastercard, Visa | 247 ([full list](https://hyperswitch.io/pm-list)) | 154 ([full list](https://hyperswitch.io/pm-list)) |
 | card | Debit Card | not supported | supported | automatic, manual, sequential automatic | supported, optional | Mastercard, Visa | 247 ([full list](https://hyperswitch.io/pm-list)) | 154 ([full list](https://hyperswitch.io/pm-list)) |
 
-### Configure Shift4
+### Authentication
 
-Enter the raw Shift4 API key in the API key field. Hyperswitch appends a colon, Base64-encodes the result, and sends it as an HTTP Basic credential ([credential mapping](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs#L835-L850), [request header](https://github.com/juspay/hyperswitch/blob/93becbaee4ee3686e1a4d5750d2e547c56c27047/crates/hyperswitch_connectors/src/connectors/shift4.rs#L112-L126)).
+Supply the raw Shift4 API key in the connector configuration. Hyperswitch appends a colon, Base64-encodes `api_key:`, and sends the result with the HTTP Basic scheme. See [`Shift4AuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs#L837-L850) and [`get_auth_header()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/shift4.rs#L112-L126).
 
-Follow the [connector activation guide](../activate-connector-on-hyperswitch/README.md) to add the credential in Hyperswitch. Use Shift4's current dashboard guidance to find the API key and register the webhook endpoint.
+### Before you start
+
+1. Register with Shift4.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. Find the API key on the Home page of your Shift4 dashboard.
+4. Enable the same payment methods in Shift4 that you plan to select in Hyperswitch.
+5. Have the credential listed in [Authentication](#authentication) ready.
+
+To connect Shift4 to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Shift4 supports.
 
 ### Webhooks
 

--- a/integration-space/connectors-integrations/available-connectors/trustpay.md
+++ b/integration-space/connectors-integrations/available-connectors/trustpay.md
@@ -63,13 +63,13 @@ The connector handles six status and credit/debit-indicator combinations. An emp
 
 The wire values and mappings are defined by [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/trustpay.rs#L1111-L1167) and [`CreditDebitIndicator`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/trustpay/transformers.rs#L2074-L2091).
 
-### Activate TrustPay with Hyperswitch
-
-#### Before you start
+### Before you start
 
 1. Register with TrustPay.
-2. Create a Hyperswitch account.
-3. Have the credentials listed in [Authentication](#authentication) ready.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. Find the API Key, Project ID, and Secret Key in your TrustPay dashboard.
+4. Enable the same payment methods in TrustPay that you plan to select in Hyperswitch.
+5. Have the credentials listed in [Authentication](#authentication) ready.
 
 To connect TrustPay to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what TrustPay supports.
 

--- a/integration-space/connectors-integrations/available-connectors/volt.md
+++ b/integration-space/connectors-integrations/available-connectors/volt.md
@@ -54,13 +54,14 @@ The connector recognizes seven webhook status values. An empty body is treated a
 
 The wire values and mappings are defined by [`VoltWebhookPaymentStatus`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/volt/transformers.rs#L730-L780).
 
-### Activate Volt with Hyperswitch
+### Before you start
 
-#### Before you start
-
-1. You need to be registered with Volt. Sign up at [volt.io](https://www.volt.io/).
-2. Create a Hyperswitch account.
-3. Have the credentials listed in [Authentication](#authentication) ready.
+1. Register with Volt.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. In the Volt dashboard, go to **Configuration → Customers** and open the merchant's **Credentials** section to find the Username and Password.
+4. Go to **Configuration → Application** and open **Credentials** to find the Client ID and Client Secret. Create an application first if none exists.
+5. Enable the same payment methods in Volt that you plan to select in Hyperswitch.
+6. Have the credentials listed in [Authentication](#authentication) ready.
 
 To connect Volt to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Volt supports.
 

--- a/integration-space/connectors-integrations/available-connectors/zen.md
+++ b/integration-space/connectors-integrations/available-connectors/zen.md
@@ -57,13 +57,13 @@ The connector handles four transaction-type and status combinations:
 
 The wire values and mappings are defined by [`get_webhook_event_type()`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/zen.rs#L654-L676), [`ZenPaymentStatus`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/zen/transformers.rs#L837-L847), and [`ZenWebhookTxnType`](https://github.com/juspay/hyperswitch/blob/a17a23c4c4c907d2314043a32a9f505f7f2bd4f9/crates/hyperswitch_connectors/src/connectors/zen/transformers.rs#L1186-L1202).
 
-### Activate Zen with Hyperswitch
+### Before you start
 
-#### Before you start
-
-1. Register with Zen.
-2. Create a Hyperswitch account.
-3. Have the credential listed in [Authentication](#authentication) ready.
+1. Register with Zen and obtain the API Key from your Zen account manager.
+2. Create or sign in to your account in the [Hyperswitch control center](https://app.hyperswitch.io/).
+3. Ask Zen support to enable raw card data handling for your account.
+4. Enable the same payment methods in Zen that you plan to select in Hyperswitch.
+5. Have the credential listed in [Authentication](#authentication) ready.
 
 To connect Zen to your Hyperswitch account, follow [Activate a connector on Hyperswitch](../activate-connector-on-hyperswitch/README.md), then return here for what Zen supports.
 


### PR DESCRIPTION
Verdict: prose-gap

The PRs this responds to: #229, #230, #231, #233, #234, #235, #236, #237, #238, and #239.

Evidence:

Repository heads used for this run:
- `juspay/hyperswitch-docs origin/main=d218567033a85737ae3c36b44340414842929078`
- `juspay/hyperswitch origin/main=740e642eabb5b54094f589d4ebc08aa9e796fab1`

A router built from the recorded Hyperswitch SHA served `GET /feature_matrix` with `connector_count=138` and `matrix canonical-json-v1 sha256=436ee4cd035a16d0`. Canonical entry comparison found no changes for these ten connectors relative to the matrix served before the restart. The generated blocks are unchanged. Their recorded fingerprints remain `matrix canonical-json-v1 sha256=36360b019f2761dd` for ACI, Authorize.net, Fiserv, Klarna, TrustPay, Volt, and Zen, and `matrix canonical-json-v1 sha256=27951de892af028b` for Braintree, Nuvei, and Shift4.

Recovered setup content, with the last page revision before its generated block arrived:
- ACI: registration, Hyperswitch control center access, and the API Key and Entity ID dashboard location from [`5ae4a944`](https://github.com/juspay/hyperswitch-docs/blob/5ae4a944404fad3e2c0769fded735df7ab132cbe/integration-space/connectors-integrations/available-connectors/aci.md#L30-L36).
- Authorize.net: registration, control center access, **Account → Security Settings**, and **Account → Digital Payment Solutions** from [`1982bfd9`](https://github.com/juspay/hyperswitch-docs/blob/1982bfd961df08cc243484f17dced899bf1a168e/integration-space/connectors-integrations/available-connectors/authorizedotnet.md#L26-L33).
- Braintree: registration, control center access, **Home → Settings → API**, and **Home → Settings → API → Webhooks** from [`a6f1ba5d`](https://github.com/juspay/hyperswitch-docs/blob/a6f1ba5d0a686d93ee274262fcfde14181d23a5b/integration-space/connectors-integrations/available-connectors/braintree.md#L28-L35).
- Fiserv: registration, control center access, **Credentials**, and payment-method matching from [`5fc22414`](https://github.com/juspay/hyperswitch-docs/blob/5fc2241465dbb65d9ec92c275d25d1efe2332711/integration-space/connectors-integrations/available-connectors/fiserv.md#L30-L37).
- Klarna: registration, control center access, **Settings → API credentials**, and payment-method matching from [`e58d990e`](https://github.com/juspay/hyperswitch-docs/blob/e58d990e7603eefc6e246d6fbc5dc86dc091b7f6/integration-space/connectors-integrations/available-connectors/klarna.md#L31-L38).
- Nuvei: registration, control center access, **Settings → My Account → Account Details**, and payment-method matching from [`d4f18d62`](https://github.com/juspay/hyperswitch-docs/blob/d4f18d62f367eea87cecf0f6729efd08ca57690d/integration-space/connectors-integrations/available-connectors/nuvei.md#L31-L38).
- Shift4: registration, control center access, the dashboard Home page, and payment-method matching from [`34058bc4`](https://github.com/juspay/hyperswitch-docs/blob/34058bc4ea58e9937140e26b48336d074360fe7b/integration-space/connectors-integrations/available-connectors/shift4.md#L25-L32).
- TrustPay: registration, control center access, the credential dashboard, and payment-method matching from [`904d9cbb`](https://github.com/juspay/hyperswitch-docs/blob/904d9cbb1bdf99131528a0555919c707748925e1/integration-space/connectors-integrations/available-connectors/trustpay.md#L31-L38).
- Volt: registration, control center access, **Configuration → Customers**, **Configuration → Application**, and payment-method matching from [`7adf35e1`](https://github.com/juspay/hyperswitch-docs/blob/7adf35e1fbe1e31bd6be691a3a7468b428e0a158/integration-space/connectors-integrations/available-connectors/volt.md#L28-L36). The retained partial setup was merged into this single section.
- Zen: registration through an account manager, control center access, raw card data enablement, and payment-method matching from [`b17c96b8`](https://github.com/juspay/hyperswitch-docs/blob/b17c96b8974fc9af4f534a016f0721fa82e9d1a9/integration-space/connectors-integrations/available-connectors/zen.md#L31-L38).

The 5d pass also moved the existing Braintree, Nuvei, and Shift4 credential mechanics into canonical Authentication sections. The constructions and mappings were exact-string checked against [`BraintreeAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/braintree/transformers.rs#L215-L237), Braintree [`get_auth_header()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/braintree.rs#L136-L149), [`NuveiAuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/nuvei/transformers.rs#L1734-L1757), Nuvei [`get_auth_header()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/nuvei.rs#L127-L133), [`Shift4AuthType::try_from()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/shift4/transformers.rs#L837-L850), and Shift4 [`get_auth_header()`](https://github.com/juspay/hyperswitch/blob/740e642eabb5b54094f589d4ebc08aa9e796fab1/crates/hyperswitch_connectors/src/connectors/shift4.rs#L112-L126). The ACI asterisk separator also failed the mechanical 5d check and was removed.

All ten canonical pages passed docs-structure-check at the docs SHA above. Each has a root copy under `other-features/connectors/`; those copies are hidden and were not edited.

What I could not check:
- I could not check the vendor dashboard paths from the sandbox. I recovered them only from each page's own history.
- I could not check the vendor signup destinations from the sandbox. I tried each historical URL with `curl -L`; the sandbox proxy returned `403 CONNECT` for all ten. The restored registration steps are generic and contain no vendor signup URL.

Page gaps:
- Vendor signup links are omitted on all ten pages because none could be live-checked from the sandbox.
- Braintree, Nuvei, and Shift4 have no Source reference section. The 5e pass reports this existing gap and does not add missing sections outside the requested restoration.

The decision the reviewer is being asked to make:
Approve the recovered setup paths and the canonical Before you start sections. Confirm the vendor dashboard paths remain current. Add vendor signup URLs only after they can be checked from an environment that can reach them.